### PR TITLE
Add windows_press_key tool for keyboard input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to FlaUI-MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `windows_press_key` tool for sending keyboard input (individual keys and modifier combinations)
+
 ## [0.1.0] - 2024-02-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Or using `dotnet run`:
 | `windows_focus` | Bring a window to foreground |
 | `windows_close` | Close a window |
 | `windows_batch` | Execute multiple actions in one call |
+| `windows_press_key` | Send keyboard input (keys and combinations) |
 
 ## How It Works
 

--- a/src/FlaUI.Mcp/Program.cs
+++ b/src/FlaUI.Mcp/Program.cs
@@ -18,6 +18,7 @@ toolRegistry.RegisterTool(new ScreenshotTool(sessionManager, elementRegistry));
 toolRegistry.RegisterTool(new ListWindowsTool(sessionManager));
 toolRegistry.RegisterTool(new FocusWindowTool(sessionManager));
 toolRegistry.RegisterTool(new CloseWindowTool(sessionManager));
+toolRegistry.RegisterTool(new PressKeyTool(elementRegistry));
 toolRegistry.RegisterTool(new BatchTool(sessionManager, elementRegistry));
 
 // Create and run MCP server

--- a/src/FlaUI.Mcp/Tools/PressKeyTool.cs
+++ b/src/FlaUI.Mcp/Tools/PressKeyTool.cs
@@ -1,0 +1,186 @@
+using System.Text.Json;
+using FlaUI.Core.Input;
+using FlaUI.Core.WindowsAPI;
+using PlaywrightWindows.Mcp.Core;
+
+namespace PlaywrightWindows.Mcp.Tools;
+
+/// <summary>
+/// Press a key or key combination. Sends keyboard input to the focused element.
+/// </summary>
+public class PressKeyTool : ToolBase
+{
+    private readonly ElementRegistry _elementRegistry;
+
+    public PressKeyTool(ElementRegistry elementRegistry)
+    {
+        _elementRegistry = elementRegistry;
+    }
+
+    public override string Name => "windows_press_key";
+
+    public override string Description =>
+        "Press a key or key combination. Sends keyboard input to the currently focused element. " +
+        "Use this for individual key presses (Enter, Escape, arrow keys, single characters as key events) " +
+        "rather than text input. Use windows_type for typing text strings.";
+
+    public override object InputSchema => new
+    {
+        type = "object",
+        properties = new
+        {
+            key = new
+            {
+                type = "string",
+                description = "Key to press: 'a'-'z', '0'-'9', 'enter', 'escape', 'tab', 'space', " +
+                              "'backspace', 'delete', 'up', 'down', 'left', 'right', 'home', 'end', " +
+                              "'pageup', 'pagedown', 'f1'-'f12', or symbols like '+', '-', '=', etc."
+            },
+            modifiers = new
+            {
+                type = "array",
+                items = new { type = "string", @enum = new[] { "ctrl", "shift", "alt" } },
+                description = "Modifier keys to hold while pressing the key (e.g., [\"ctrl\", \"shift\"])"
+            },
+            @ref = new
+            {
+                type = "string",
+                description = "Element ref to focus before pressing the key. If omitted, sends to the currently focused element."
+            }
+        },
+        required = new[] { "key" }
+    };
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var keyName = GetStringArgument(arguments, "key");
+        if (string.IsNullOrEmpty(keyName))
+        {
+            return Task.FromResult(ErrorResult("Missing required argument: key"));
+        }
+
+        var modifiers = GetArgument<string[]>(arguments, "modifiers") ?? Array.Empty<string>();
+        var refId = GetStringArgument(arguments, "ref");
+
+        try
+        {
+            // Focus element if ref provided
+            if (!string.IsNullOrEmpty(refId))
+            {
+                var element = _elementRegistry.GetElement(refId);
+                if (element == null)
+                {
+                    return Task.FromResult(ErrorResult($"Element not found: {refId}. Run windows_snapshot to refresh element refs."));
+                }
+
+                element.Focus();
+                Thread.Sleep(50);
+            }
+
+            var vk = MapKeyName(keyName);
+            if (vk == null)
+            {
+                return Task.FromResult(ErrorResult($"Unknown key: '{keyName}'"));
+            }
+
+            // Build modifier list
+            var modifierKeys = new List<VirtualKeyShort>();
+            foreach (var mod in modifiers)
+            {
+                var modKey = mod.ToLowerInvariant() switch
+                {
+                    "ctrl" or "control" => VirtualKeyShort.CONTROL,
+                    "shift" => VirtualKeyShort.SHIFT,
+                    "alt" => VirtualKeyShort.ALT,
+                    _ => (VirtualKeyShort?)null
+                };
+                if (modKey == null)
+                {
+                    return Task.FromResult(ErrorResult($"Unknown modifier: '{mod}'. Use 'ctrl', 'shift', or 'alt'."));
+                }
+                modifierKeys.Add(modKey.Value);
+            }
+
+            // Press the key with modifiers
+            if (modifierKeys.Count > 0)
+            {
+                var allKeys = modifierKeys.Append(vk.Value).ToArray();
+                Keyboard.TypeSimultaneously(allKeys);
+            }
+            else
+            {
+                Keyboard.Press(vk.Value);
+            }
+
+            // Build description
+            var desc = string.Join("+", modifiers.Select(m => m.ToUpperInvariant()).Append(keyName));
+            var target = string.IsNullOrEmpty(refId) ? "" : $" (focused {refId})";
+            return Task.FromResult(TextResult($"Pressed {desc}{target}"));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ErrorResult($"Failed to press key: {ex.Message}"));
+        }
+    }
+
+    private static VirtualKeyShort? MapKeyName(string keyName)
+    {
+        // Single character keys
+        if (keyName.Length == 1)
+        {
+            var ch = keyName[0];
+            return ch switch
+            {
+                >= 'a' and <= 'z' => (VirtualKeyShort)((int)VirtualKeyShort.KEY_A + (ch - 'a')),
+                >= 'A' and <= 'Z' => (VirtualKeyShort)((int)VirtualKeyShort.KEY_A + (ch - 'A')),
+                >= '0' and <= '9' => (VirtualKeyShort)((int)VirtualKeyShort.KEY_0 + (ch - '0')),
+                ' ' => VirtualKeyShort.SPACE,
+                '+' or '=' => VirtualKeyShort.OEM_PLUS,
+                '-' => VirtualKeyShort.OEM_MINUS,
+                '.' => VirtualKeyShort.OEM_PERIOD,
+                ',' => VirtualKeyShort.OEM_COMMA,
+                '/' => VirtualKeyShort.OEM_2,
+                ';' => VirtualKeyShort.OEM_1,
+                '\'' => VirtualKeyShort.OEM_7,
+                '[' => VirtualKeyShort.OEM_4,
+                ']' => VirtualKeyShort.OEM_6,
+                '\\' => VirtualKeyShort.OEM_5,
+                '`' => VirtualKeyShort.OEM_3,
+                _ => null
+            };
+        }
+
+        // Named keys
+        return keyName.ToLowerInvariant() switch
+        {
+            "enter" or "return" => VirtualKeyShort.ENTER,
+            "escape" or "esc" => VirtualKeyShort.ESCAPE,
+            "tab" => VirtualKeyShort.TAB,
+            "space" => VirtualKeyShort.SPACE,
+            "backspace" or "back" => VirtualKeyShort.BACK,
+            "delete" or "del" => VirtualKeyShort.DELETE,
+            "up" => VirtualKeyShort.UP,
+            "down" => VirtualKeyShort.DOWN,
+            "left" => VirtualKeyShort.LEFT,
+            "right" => VirtualKeyShort.RIGHT,
+            "home" => VirtualKeyShort.HOME,
+            "end" => VirtualKeyShort.END,
+            "pageup" => VirtualKeyShort.PRIOR,
+            "pagedown" => VirtualKeyShort.NEXT,
+            "insert" => VirtualKeyShort.INSERT,
+            "f1" => VirtualKeyShort.F1,
+            "f2" => VirtualKeyShort.F2,
+            "f3" => VirtualKeyShort.F3,
+            "f4" => VirtualKeyShort.F4,
+            "f5" => VirtualKeyShort.F5,
+            "f6" => VirtualKeyShort.F6,
+            "f7" => VirtualKeyShort.F7,
+            "f8" => VirtualKeyShort.F8,
+            "f9" => VirtualKeyShort.F9,
+            "f10" => VirtualKeyShort.F10,
+            "f11" => VirtualKeyShort.F11,
+            "f12" => VirtualKeyShort.F12,
+            _ => null
+        };
+    }
+}

--- a/src/FlaUI.Mcp/Tools/PressKeyTool.cs
+++ b/src/FlaUI.Mcp/Tools/PressKeyTool.cs
@@ -51,12 +51,12 @@ public class PressKeyTool : ToolBase
         required = new[] { "key" }
     };
 
-    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    public override async Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
     {
         var keyName = GetStringArgument(arguments, "key");
         if (string.IsNullOrEmpty(keyName))
         {
-            return Task.FromResult(ErrorResult("Missing required argument: key"));
+            return ErrorResult("Missing required argument: key");
         }
 
         var modifiers = GetArgument<string[]>(arguments, "modifiers") ?? Array.Empty<string>();
@@ -70,17 +70,17 @@ public class PressKeyTool : ToolBase
                 var element = _elementRegistry.GetElement(refId);
                 if (element == null)
                 {
-                    return Task.FromResult(ErrorResult($"Element not found: {refId}. Run windows_snapshot to refresh element refs."));
+                    return ErrorResult($"Element not found: {refId}. Run windows_snapshot to refresh element refs.");
                 }
 
                 element.Focus();
-                Thread.Sleep(50);
+                await Task.Delay(50);
             }
 
             var vk = MapKeyName(keyName);
             if (vk == null)
             {
-                return Task.FromResult(ErrorResult($"Unknown key: '{keyName}'"));
+                return ErrorResult($"Unknown key: '{keyName}'");
             }
 
             // Build modifier list
@@ -96,7 +96,7 @@ public class PressKeyTool : ToolBase
                 };
                 if (modKey == null)
                 {
-                    return Task.FromResult(ErrorResult($"Unknown modifier: '{mod}'. Use 'ctrl', 'shift', or 'alt'."));
+                    return ErrorResult($"Unknown modifier: '{mod}'. Use 'ctrl', 'shift', or 'alt'.");
                 }
                 modifierKeys.Add(modKey.Value);
             }
@@ -115,11 +115,11 @@ public class PressKeyTool : ToolBase
             // Build description
             var desc = string.Join("+", modifiers.Select(m => m.ToUpperInvariant()).Append(keyName));
             var target = string.IsNullOrEmpty(refId) ? "" : $" (focused {refId})";
-            return Task.FromResult(TextResult($"Pressed {desc}{target}"));
+            return TextResult($"Pressed {desc}{target}");
         }
         catch (Exception ex)
         {
-            return Task.FromResult(ErrorResult($"Failed to press key: {ex.Message}"));
+            return ErrorResult($"Failed to press key: {ex.Message}");
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `windows_press_key` tool for sending individual key presses and key combinations
- Supports named keys (Enter, Escape, Tab, arrow keys, F1-F12), single character keys (a-z, 0-9), and symbols
- Supports modifier combinations (Ctrl, Shift, Alt) — e.g., Ctrl+C, Alt+F4
- Optional `ref` parameter to focus an element before pressing the key

This fills a gap between `windows_click` (element interaction) and `windows_type` (text input) — there was no way to send individual keystrokes like Enter to dismiss a dialog, Tab to navigate between fields, or Ctrl+A to select all.

## Examples

```json
{"name": "windows_press_key", "arguments": {"key": "Enter"}}
{"name": "windows_press_key", "arguments": {"key": "a", "modifiers": ["ctrl"]}}
{"name": "windows_press_key", "arguments": {"key": "F5"}}
{"name": "windows_press_key", "arguments": {"key": "Tab", "ref": "w1e5"}}
```

## Test plan

- [x] Build succeeds with zero errors
- [x] `windows_press_key` with plain keys (Tab, Escape) works
- [x] `windows_press_key` with modifier combinations (Ctrl+A) works
- [x] `windows_press_key` with `ref` parameter focuses element first
- [x] Unknown key names return clear error message
- [x] Unknown modifier names return clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)