### PR TITLE
Add windows_get_value tool for reading element values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to FlaUI-MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `windows_get_value` tool for reading element values via the Value automation pattern
+
 ## [0.1.0] - 2024-02-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Or using `dotnet run`:
 | `windows_focus` | Bring a window to foreground |
 | `windows_close` | Close a window |
 | `windows_batch` | Execute multiple actions in one call |
+| `windows_get_value` | Get an element's value via the Value pattern |
 
 ## How It Works
 

--- a/src/FlaUI.Mcp/Program.cs
+++ b/src/FlaUI.Mcp/Program.cs
@@ -14,6 +14,7 @@ toolRegistry.RegisterTool(new ClickTool(elementRegistry));
 toolRegistry.RegisterTool(new TypeTool(elementRegistry));
 toolRegistry.RegisterTool(new FillTool(elementRegistry));
 toolRegistry.RegisterTool(new GetTextTool(elementRegistry));
+toolRegistry.RegisterTool(new GetValueTool(elementRegistry));
 toolRegistry.RegisterTool(new ScreenshotTool(sessionManager, elementRegistry));
 toolRegistry.RegisterTool(new ListWindowsTool(sessionManager));
 toolRegistry.RegisterTool(new FocusWindowTool(sessionManager));

--- a/src/FlaUI.Mcp/Tools/GetValueTool.cs
+++ b/src/FlaUI.Mcp/Tools/GetValueTool.cs
@@ -1,0 +1,100 @@
+using System.Text.Json;
+using FlaUI.Core.Definitions;
+using PlaywrightWindows.Mcp.Core;
+
+namespace PlaywrightWindows.Mcp.Tools;
+
+/// <summary>
+/// Get the programmatic value of an element (Value pattern, Toggle state, Selection state, RangeValue, etc.)
+/// </summary>
+public class GetValueTool : ToolBase
+{
+    private readonly ElementRegistry _elementRegistry;
+
+    public GetValueTool(ElementRegistry elementRegistry)
+    {
+        _elementRegistry = elementRegistry;
+    }
+
+    public override string Name => "windows_get_value";
+
+    public override string Description =>
+        "Get the programmatic value of an element. Reads the Value pattern for inputs, " +
+        "Toggle state for checkboxes, Selection state for list items, and RangeValue for " +
+        "sliders/progress bars. Distinct from windows_get_text which returns display text.";
+
+    public override object InputSchema => new
+    {
+        type = "object",
+        properties = new
+        {
+            @ref = new
+            {
+                type = "string",
+                description = "Element ref from windows_snapshot (e.g., 'w1e5')"
+            }
+        },
+        required = new[] { "ref" }
+    };
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var refId = GetStringArgument(arguments, "ref");
+        if (string.IsNullOrEmpty(refId))
+        {
+            return Task.FromResult(ErrorResult("Missing required argument: ref"));
+        }
+
+        var element = _elementRegistry.GetElement(refId);
+        if (element == null)
+        {
+            return Task.FromResult(ErrorResult($"Element not found: {refId}. Run windows_snapshot to refresh element refs."));
+        }
+
+        try
+        {
+            // 1. Value pattern (text inputs, combo boxes, etc.)
+            if (element.Patterns.Value.IsSupported)
+            {
+                var value = element.Patterns.Value.Pattern.Value.ValueOrDefault ?? "";
+                return Task.FromResult(TextResult(value));
+            }
+
+            // 2. Toggle pattern (checkboxes, toggle buttons)
+            if (element.Patterns.Toggle.IsSupported)
+            {
+                var toggleState = element.Patterns.Toggle.Pattern.ToggleState.ValueOrDefault;
+                var stateText = toggleState switch
+                {
+                    ToggleState.On => "checked",
+                    ToggleState.Off => "unchecked",
+                    ToggleState.Indeterminate => "indeterminate",
+                    _ => toggleState.ToString()
+                };
+                return Task.FromResult(TextResult(stateText));
+            }
+
+            // 3. SelectionItem pattern (list items, radio buttons)
+            if (element.Patterns.SelectionItem.IsSupported)
+            {
+                var isSelected = element.Patterns.SelectionItem.Pattern.IsSelected.ValueOrDefault;
+                return Task.FromResult(TextResult(isSelected ? "selected" : "unselected"));
+            }
+
+            // 4. RangeValue pattern (sliders, progress bars, spinners)
+            if (element.Patterns.RangeValue.IsSupported)
+            {
+                var rangeValue = element.Patterns.RangeValue.Pattern.Value.ValueOrDefault;
+                return Task.FromResult(TextResult(rangeValue.ToString()));
+            }
+
+            // 5. Fall back to Name property
+            var name = element.Properties.Name.ValueOrDefault ?? "";
+            return Task.FromResult(TextResult(name));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ErrorResult($"Failed to get value from {refId}: {ex.Message}"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `windows_get_value` tool that reads the programmatic value of a UI element
- Priority order: Value pattern → Toggle state → SelectionItem state → RangeValue → Name fallback
- Distinct from `windows_get_text` which focuses on display text/Name property

Useful for reading checkbox states, slider values, combo box selections, and custom accessible values from data-bound controls.

## Test plan

- [x] Build succeeds with zero errors
- [x] Returns element Name as fallback for elements without Value pattern
- [x] Tool registered and appears in `tools/list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)