### PR TITLE
Add windows_find query tool for targeted element discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to FlaUI-MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `windows_find` tool for targeted element discovery by name, automationId, role, or UIA pattern
+
+### Fixed
+- `windows_find` no longer reports stale disabled state for elements
+
 ## [0.1.0] - 2024-02-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Or using `dotnet run`:
 | `windows_focus` | Bring a window to foreground |
 | `windows_close` | Close a window |
 | `windows_batch` | Execute multiple actions in one call |
+| `windows_find` | Search for elements by name, automationId, role, or pattern |
 
 ## How It Works
 

--- a/src/FlaUI.Mcp/Core/SnapshotBuilder.cs
+++ b/src/FlaUI.Mcp/Core/SnapshotBuilder.cs
@@ -62,7 +62,14 @@ public class SnapshotBuilder
         }
     }
 
-    private string BuildElementLine(AutomationElement element, string refId, string? name, string role)
+    public static string FormatElementLine(AutomationElement element, string refId)
+    {
+        var name = GetElementName(element);
+        var role = GetElementRole(element);
+        return BuildElementLine(element, refId, name, role);
+    }
+
+    private static string BuildElementLine(AutomationElement element, string refId, string? name, string role)
     {
         var parts = new List<string>();
 
@@ -88,7 +95,7 @@ public class SnapshotBuilder
         return string.Join(" ", parts);
     }
 
-    private string GetElementRole(AutomationElement element)
+    public static string GetElementRole(AutomationElement element)
     {
         try
         {
@@ -141,7 +148,7 @@ public class SnapshotBuilder
         }
     }
 
-    private string? GetElementName(AutomationElement element)
+    public static string? GetElementName(AutomationElement element)
     {
         try
         {
@@ -163,7 +170,7 @@ public class SnapshotBuilder
         }
     }
 
-    private List<string> GetStateIndicators(AutomationElement element)
+    public static List<string> GetStateIndicators(AutomationElement element)
     {
         var states = new List<string>();
 
@@ -246,7 +253,7 @@ public class SnapshotBuilder
         return false;
     }
 
-    private string EscapeName(string name)
+    public static string EscapeName(string name)
     {
         return name
             .Replace("\\", "\\\\")

--- a/src/FlaUI.Mcp/Program.cs
+++ b/src/FlaUI.Mcp/Program.cs
@@ -10,6 +10,7 @@ var elementRegistry = new ElementRegistry();
 var toolRegistry = new ToolRegistry();
 toolRegistry.RegisterTool(new LaunchTool(sessionManager));
 toolRegistry.RegisterTool(new SnapshotTool(sessionManager, elementRegistry));
+toolRegistry.RegisterTool(new FindTool(sessionManager, elementRegistry));
 toolRegistry.RegisterTool(new ClickTool(elementRegistry));
 toolRegistry.RegisterTool(new TypeTool(elementRegistry));
 toolRegistry.RegisterTool(new FillTool(elementRegistry));

--- a/src/FlaUI.Mcp/Tools/FindTool.cs
+++ b/src/FlaUI.Mcp/Tools/FindTool.cs
@@ -1,0 +1,287 @@
+using System.Text;
+using System.Text.Json;
+using FlaUI.Core.AutomationElements;
+using PlaywrightWindows.Mcp.Core;
+
+namespace PlaywrightWindows.Mcp.Tools;
+
+/// <summary>
+/// Search for elements matching criteria, returning only matching elements instead of the full tree
+/// </summary>
+public class FindTool : ToolBase
+{
+    private readonly SessionManager _sessionManager;
+    private readonly ElementRegistry _elementRegistry;
+
+    public FindTool(SessionManager sessionManager, ElementRegistry elementRegistry)
+    {
+        _sessionManager = sessionManager;
+        _elementRegistry = elementRegistry;
+    }
+
+    public override string Name => "windows_find";
+
+    public override string Description =>
+        "Search for UI elements matching criteria. Returns matching elements with refs that can be used " +
+        "with other tools. More targeted than windows_snapshot - use when you know what you're looking for.";
+
+    public override object InputSchema => new
+    {
+        type = "object",
+        properties = new
+        {
+            handle = new
+            {
+                type = "string",
+                description = "Window handle from windows_launch or windows_list_windows. If omitted, uses the focused window."
+            },
+            name = new
+            {
+                type = "string",
+                description = "Substring match on element Name property (case-insensitive)"
+            },
+            automationId = new
+            {
+                type = "string",
+                description = "Exact match on AutomationId"
+            },
+            role = new
+            {
+                type = "string",
+                description = "Filter by role (e.g., \"button\", \"textbox\", \"table\", \"checkbox\")"
+            },
+            depth = new
+            {
+                type = "integer",
+                description = "Max traversal depth (default: 10)"
+            },
+            pattern = new
+            {
+                type = "string",
+                description = "Filter by supported UIA pattern: \"invoke\", \"value\", \"toggle\", \"selection\", \"expandcollapse\", \"scroll\", \"grid\", \"table\", \"text\", \"rangevalue\"",
+                @enum = new[] { "invoke", "value", "toggle", "selection", "expandcollapse", "scroll", "grid", "table", "text", "rangevalue" }
+            }
+        }
+    };
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var handle = GetStringArgument(arguments, "handle");
+        var nameFilter = GetStringArgument(arguments, "name");
+        var automationIdFilter = GetStringArgument(arguments, "automationId");
+        var roleFilter = GetStringArgument(arguments, "role");
+        var depthArg = GetArgument<int?>(arguments, "depth");
+        var patternFilter = GetStringArgument(arguments, "pattern");
+
+        int maxDepth = depthArg ?? 10;
+
+        try
+        {
+            FlaUI.Core.AutomationElements.Window? window = null;
+
+            if (!string.IsNullOrEmpty(handle))
+            {
+                window = _sessionManager.GetWindow(handle);
+                if (window == null)
+                {
+                    return Task.FromResult(ErrorResult($"Window not found: {handle}"));
+                }
+            }
+            else
+            {
+                // Get the foreground window (same logic as SnapshotTool)
+                var focusedElement = _sessionManager.Automation.FocusedElement();
+
+                if (focusedElement != null)
+                {
+                    var current = focusedElement;
+                    while (current != null)
+                    {
+                        if (current.Properties.ControlType.ValueOrDefault == FlaUI.Core.Definitions.ControlType.Window)
+                        {
+                            window = current.AsWindow();
+                            break;
+                        }
+                        current = current.Parent;
+                    }
+                }
+
+                if (window == null)
+                {
+                    return Task.FromResult(ErrorResult("No window specified and no focused window found. Use windows_list_windows to see available windows."));
+                }
+
+                handle = _sessionManager.RegisterWindow(window);
+            }
+
+            // Validate pattern filter if provided
+            if (!string.IsNullOrEmpty(patternFilter) && !IsValidPattern(patternFilter))
+            {
+                return Task.FromResult(ErrorResult($"Unknown pattern: {patternFilter}. Valid patterns: invoke, value, toggle, selection, expandcollapse, scroll, grid, table, text, rangevalue"));
+            }
+
+            var matches = new List<(AutomationElement Element, string RefId)>();
+            FindMatchingElements(handle!, window, matches, nameFilter, automationIdFilter, roleFilter, patternFilter, 0, maxDepth);
+
+            if (matches.Count == 0)
+            {
+                return Task.FromResult(TextResult("No matching elements found."));
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Found {matches.Count} matching element(s):");
+            foreach (var (element, refId) in matches)
+            {
+                var line = SnapshotBuilder.FormatElementLine(element, refId);
+                sb.AppendLine($"- {line}");
+            }
+
+            return Task.FromResult(TextResult(sb.ToString()));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ErrorResult($"Find failed: {ex.Message}"));
+        }
+    }
+
+    private void FindMatchingElements(
+        string windowHandle,
+        AutomationElement element,
+        List<(AutomationElement, string)> matches,
+        string? nameFilter,
+        string? automationIdFilter,
+        string? roleFilter,
+        string? patternFilter,
+        int currentDepth,
+        int maxDepth)
+    {
+        if (currentDepth > maxDepth) return;
+
+        if (MatchesCriteria(element, nameFilter, automationIdFilter, roleFilter, patternFilter))
+        {
+            var refId = _elementRegistry.Register(windowHandle, element);
+            matches.Add((element, refId));
+        }
+
+        // Recurse into children
+        try
+        {
+            var children = element.FindAllChildren();
+            foreach (var child in children)
+            {
+                FindMatchingElements(windowHandle, child, matches, nameFilter, automationIdFilter, roleFilter, patternFilter, currentDepth + 1, maxDepth);
+            }
+        }
+        catch
+        {
+            // Some elements throw when accessing children
+        }
+    }
+
+    private static bool MatchesCriteria(
+        AutomationElement element,
+        string? nameFilter,
+        string? automationIdFilter,
+        string? roleFilter,
+        string? patternFilter)
+    {
+        // At least one filter must be specified (otherwise everything matches)
+        bool hasFilter = !string.IsNullOrEmpty(nameFilter)
+                      || !string.IsNullOrEmpty(automationIdFilter)
+                      || !string.IsNullOrEmpty(roleFilter)
+                      || !string.IsNullOrEmpty(patternFilter);
+        if (!hasFilter) return false;
+
+        // Name: substring match, case-insensitive
+        if (!string.IsNullOrEmpty(nameFilter))
+        {
+            try
+            {
+                var elementName = element.Properties.Name.ValueOrDefault;
+                if (string.IsNullOrEmpty(elementName) ||
+                    !elementName.Contains(nameFilter, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        // AutomationId: exact match
+        if (!string.IsNullOrEmpty(automationIdFilter))
+        {
+            try
+            {
+                var autoId = element.Properties.AutomationId.ValueOrDefault;
+                if (!string.Equals(autoId, automationIdFilter, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        // Role: match against the mapped role string
+        if (!string.IsNullOrEmpty(roleFilter))
+        {
+            var role = SnapshotBuilder.GetElementRole(element);
+            if (!string.Equals(role, roleFilter, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        // Pattern: check if the element supports the specified UIA pattern
+        if (!string.IsNullOrEmpty(patternFilter))
+        {
+            if (!SupportsPattern(element, patternFilter))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsValidPattern(string pattern)
+    {
+        return pattern.ToLowerInvariant() switch
+        {
+            "invoke" or "value" or "toggle" or "selection" or
+            "expandcollapse" or "scroll" or "grid" or "table" or
+            "text" or "rangevalue" => true,
+            _ => false
+        };
+    }
+
+    private static bool SupportsPattern(AutomationElement element, string pattern)
+    {
+        try
+        {
+            return pattern.ToLowerInvariant() switch
+            {
+                "invoke" => element.Patterns.Invoke.IsSupported,
+                "value" => element.Patterns.Value.IsSupported,
+                "toggle" => element.Patterns.Toggle.IsSupported,
+                "selection" => element.Patterns.SelectionItem.IsSupported,
+                "expandcollapse" => element.Patterns.ExpandCollapse.IsSupported,
+                "scroll" => element.Patterns.Scroll.IsSupported,
+                "grid" => element.Patterns.Grid.IsSupported,
+                "table" => element.Patterns.Table.IsSupported,
+                "text" => element.Patterns.Text.IsSupported,
+                "rangevalue" => element.Patterns.RangeValue.IsSupported,
+                _ => false
+            };
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/FlaUI.Mcp/Tools/FindTool.cs
+++ b/src/FlaUI.Mcp/Tools/FindTool.cs
@@ -86,6 +86,22 @@ public class FindTool : ToolBase
                 {
                     return Task.FromResult(ErrorResult($"Window not found: {handle}"));
                 }
+
+                // Re-find the window from desktop to get fresh element tree
+                // This avoids stale cached properties from a previous snapshot
+                try
+                {
+                    var desktop = _sessionManager.Automation.GetDesktop();
+                    var freshWindow = desktop.FindFirstDescendant(cf => cf.ByName(window.Title))?.AsWindow();
+                    if (freshWindow != null)
+                    {
+                        window = freshWindow;
+                    }
+                }
+                catch
+                {
+                    // Fall through to use the cached window if refresh fails
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary

- Adds `windows_find` tool for searching elements by name, automationId, role, depth, and UIA pattern
- Returns only matching elements with refs, avoiding the cost of a full `windows_snapshot`
- All specified criteria use AND logic
- Refreshes window reference from desktop before searching to avoid stale cached properties

Designed for cases where `windows_snapshot` returns too much data — find specific buttons, text fields, or controls by their properties.

## Test plan

- [x] Build succeeds with zero errors
- [x] Role filter returns matching elements (e.g., all buttons)
- [x] Name + role filter narrows results correctly
- [x] Pattern filter works (e.g., `pattern: "toggle"`)
- [x] Returned refs work with other tools (`windows_click`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)