### PR TITLE
Add UIA2 fallback backend for WinForms controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to FlaUI-MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- UIA2 fallback backend for improved WinForms control automation (`backend` parameter on `windows_snapshot` and `windows_batch`)
+
 ## [0.1.0] - 2024-02-02
 
 ### Added

--- a/src/FlaUI.Mcp/Core/SessionManager.cs
+++ b/src/FlaUI.Mcp/Core/SessionManager.cs
@@ -1,5 +1,6 @@
 using FlaUI.Core;
 using FlaUI.Core.AutomationElements;
+using FlaUI.UIA2;
 using FlaUI.UIA3;
 using FlaUIApplication = FlaUI.Core.Application;
 
@@ -11,6 +12,7 @@ namespace PlaywrightWindows.Mcp.Core;
 public class SessionManager : IDisposable
 {
     private readonly UIA3Automation _automation;
+    private UIA2Automation? _uia2Automation;
     private readonly Dictionary<string, FlaUIApplication> _applications = new();
     private readonly Dictionary<string, Window> _windows = new();
     private int _appCounter = 0;
@@ -22,6 +24,8 @@ public class SessionManager : IDisposable
     }
 
     public UIA3Automation Automation => _automation;
+
+    public UIA2Automation UIA2Automation => _uia2Automation ??= new UIA2Automation();
 
     public (string handle, Window window) LaunchApp(string appPath, string[]? args = null)
     {
@@ -182,6 +186,7 @@ public class SessionManager : IDisposable
         }
         _applications.Clear();
         _windows.Clear();
+        _uia2Automation?.Dispose();
         _automation.Dispose();
     }
 }

--- a/src/FlaUI.Mcp/FlaUI.Mcp.csproj
+++ b/src/FlaUI.Mcp/FlaUI.Mcp.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="FlaUI.Core" Version="5.0.0" />
+    <PackageReference Include="FlaUI.UIA2" Version="5.0.0" />
     <PackageReference Include="FlaUI.UIA3" Version="5.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.2" />
     <PackageReference Include="System.Text.Json" Version="10.0.2" />

--- a/src/FlaUI.Mcp/Tools/BatchTool.cs
+++ b/src/FlaUI.Mcp/Tools/BatchTool.cs
@@ -72,6 +72,12 @@ public class BatchTool : ToolBase
                         {
                             type = "string",
                             description = "Window handle for snapshot action"
+                        },
+                        backend = new
+                        {
+                            type = "string",
+                            @enum = new[] { "uia3", "uia2" },
+                            description = "Automation backend for snapshot action. UIA3 (default) works best for WPF/UWP. UIA2 may provide better results for older WinForms controls."
                         }
                     },
                     required = new[] { "action" }
@@ -233,7 +239,8 @@ public class BatchTool : ToolBase
     private string ExecuteSnapshot(JsonElement action)
     {
         var handle = action.TryGetProperty("handle", out var handleProp) ? handleProp.GetString() : null;
-        
+        var backend = action.TryGetProperty("backend", out var backendProp) ? backendProp.GetString() : null;
+
         Window? window = null;
         if (!string.IsNullOrEmpty(handle))
         {
@@ -266,6 +273,19 @@ public class BatchTool : ToolBase
         if (window == null)
         {
             return "No window found";
+        }
+
+        // If UIA2 backend requested, re-find the window using UIA2
+        if (string.Equals(backend, "uia2", StringComparison.OrdinalIgnoreCase))
+        {
+            var uia2 = _sessionManager.UIA2Automation;
+            var uia2Desktop = uia2.GetDesktop();
+            var windowTitle = window.Title;
+            var uia2Window = uia2Desktop.FindFirstDescendant(cf => cf.ByName(windowTitle))?.AsWindow();
+            if (uia2Window != null)
+            {
+                window = uia2Window;
+            }
         }
 
         var snapshot = _snapshotBuilder.BuildSnapshot(handle!, window);

--- a/src/FlaUI.Mcp/Tools/SnapshotTool.cs
+++ b/src/FlaUI.Mcp/Tools/SnapshotTool.cs
@@ -36,6 +36,12 @@ public class SnapshotTool : ToolBase
             {
                 type = "string",
                 description = "Window handle from windows_launch or windows_list_windows. If omitted, uses the most recently launched window."
+            },
+            backend = new
+            {
+                type = "string",
+                @enum = new[] { "uia3", "uia2" },
+                description = "Automation backend to use. UIA3 (default) works best for WPF/UWP. UIA2 may provide better results for older WinForms controls."
             }
         }
     };
@@ -43,6 +49,7 @@ public class SnapshotTool : ToolBase
     public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
     {
         var handle = GetStringArgument(arguments, "handle");
+        var backend = GetStringArgument(arguments, "backend");
 
         try
         {
@@ -61,7 +68,7 @@ public class SnapshotTool : ToolBase
                 // Get the foreground window
                 var desktop = _sessionManager.Automation.GetDesktop();
                 var focusedElement = _sessionManager.Automation.FocusedElement();
-                
+
                 if (focusedElement != null)
                 {
                     // Walk up to find the window
@@ -84,6 +91,19 @@ public class SnapshotTool : ToolBase
 
                 // Register this window
                 handle = _sessionManager.RegisterWindow(window);
+            }
+
+            // If UIA2 backend requested, re-find the window using UIA2
+            if (string.Equals(backend, "uia2", StringComparison.OrdinalIgnoreCase))
+            {
+                var uia2 = _sessionManager.UIA2Automation;
+                var uia2Desktop = uia2.GetDesktop();
+                var windowTitle = window.Title;
+                var uia2Window = uia2Desktop.FindFirstDescendant(cf => cf.ByName(windowTitle))?.AsWindow();
+                if (uia2Window != null)
+                {
+                    window = uia2Window;
+                }
             }
 
             var snapshot = _snapshotBuilder.BuildSnapshot(handle!, window);


### PR DESCRIPTION
## Summary

- Adds optional `backend` parameter to `windows_snapshot`: `"uia3"` (default) or `"uia2"`
- UIA2 backend provides better accessibility data for some WinForms controls, particularly older custom controls that implement IAccessible/MSAA
- UIA2 automation instance is lazy-initialized (only created if requested)
- Also supported in `windows_batch` snapshot action

FlaUI already supports both UIA2 and UIA3 backends. This exposes that choice to the caller.

## Test plan

- [x] Build succeeds with zero errors
- [x] `backend: "uia3"` returns snapshot (same as default)
- [x] `backend: "uia2"` returns snapshot with subtly different control types
- [x] Default behavior (no backend) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)