### PR TITLE
Add integration test framework with WinForms and WPF test apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to FlaUI-MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Integration test framework** with purpose-built WinForms (.NET Framework 4.8.1) and WPF (.NET 8) test applications
+  - WinFormsTestApp: buttons, forms, 50-row DataGridView, TreeView, dialog launchers
+  - WpfTestApp: equivalent WPF controls for cross-framework validation
+  - 13 integration tests covering snapshot, click, and text tools
+  - Shared test fixture for stable window handles across test runs
+
 ## [0.1.0] - 2024-02-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -147,6 +147,21 @@ dotnet build src/FlaUI.Mcp
 dotnet run --project src/FlaUI.Mcp
 ```
 
+## Testing
+
+The project includes integration tests that launch purpose-built WinForms and WPF test applications and exercise the MCP tools against real Windows UI controls.
+
+```powershell
+# Build the test apps first
+dotnet build tests/TestApps/WinFormsTestApp
+dotnet build tests/TestApps/WpfTestApp
+
+# Run integration tests
+dotnet test tests/FlaUI.Mcp.IntegrationTests
+```
+
+> **Note:** Tests require a Windows desktop environment (they launch GUI applications) and cannot run in headless CI.
+
 ## Architecture
 
 ```

--- a/tests/FlaUI.Mcp.IntegrationTests/ClickTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/ClickTests.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using PlaywrightWindows.Mcp;
+using PlaywrightWindows.Mcp.Core;
+using PlaywrightWindows.Mcp.Tools;
+using Xunit.Abstractions;
+
+namespace FlaUI.Mcp.IntegrationTests;
+
+/// <summary>
+/// Tests for windows_click tool using the test apps.
+/// </summary>
+[Collection("TestApps")]
+public class ClickTests
+{
+    private readonly TestAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public ClickTests(TestAppFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    private async Task<string> CallTool(ToolBase tool, object args)
+    {
+        var json = JsonSerializer.Serialize(args, McpProtocol.JsonOptions);
+        var element = JsonSerializer.Deserialize<JsonElement>(json);
+        var result = await tool.ExecuteAsync(element);
+        var text = result.Content.FirstOrDefault()?.Text ?? "";
+        _output.WriteLine($"Result: {text}");
+        return text;
+    }
+
+    private string? FindRefByName(string handle, string name)
+    {
+        var builder = new SnapshotBuilder(_fixture.Elements);
+        var window = _fixture.Session.GetWindow(handle)!;
+        var snapshot = builder.BuildSnapshot(handle, window);
+        // Parse snapshot to find ref for element with given name
+        foreach (var line in snapshot.Split('\n'))
+        {
+            if (line.Contains($"\"{name}\"") && line.Contains("[ref="))
+            {
+                var refStart = line.IndexOf("[ref=") + 5;
+                var refEnd = line.IndexOf("]", refStart);
+                return line[refStart..refEnd];
+            }
+        }
+        return null;
+    }
+
+    [Fact]
+    public async Task WinForms_Click_Button_Invoke()
+    {
+        var buttonRef = FindRefByName(_fixture.WinFormsHandle, "Click Me");
+        Assert.NotNull(buttonRef);
+        _output.WriteLine($"Click Me button ref: {buttonRef}");
+
+        var tool = new ClickTool(_fixture.Elements);
+        var result = await CallTool(tool, new { @ref = buttonRef });
+        Assert.Contains("Invoked", result);
+    }
+
+    [Fact]
+    public async Task WinForms_Click_Checkbox_Toggle()
+    {
+        var cbRef = FindRefByName(_fixture.WinFormsHandle, "Enable the button below");
+        Assert.NotNull(cbRef);
+
+        var tool = new ClickTool(_fixture.Elements);
+        var result = await CallTool(tool, new { @ref = cbRef });
+        // WinForms checkboxes support InvokePattern, so ClickTool uses Invoke (not Toggle)
+        Assert.True(result.Contains("Invoked") || result.Contains("Toggled"), $"Expected Invoked or Toggled, got: {result}");
+
+        // Toggle back to original state
+        await CallTool(tool, new { @ref = cbRef });
+    }
+
+    [Fact]
+    public async Task WinForms_EnabledStateChanges_AfterCheckboxClick()
+    {
+        // First snapshot to find refs
+        var builder = new SnapshotBuilder(_fixture.Elements);
+        var window = _fixture.GetWinFormsWindow()!;
+        var snapshot1 = builder.BuildSnapshot(_fixture.WinFormsHandle, window);
+        _output.WriteLine("Initial snapshot (partial):");
+        foreach (var line in snapshot1.Split('\n'))
+        {
+            if (line.Contains("Conditional") || line.Contains("Enable"))
+                _output.WriteLine(line);
+        }
+
+        // Find the checkbox and button refs
+        var cbRef = FindRefByName(_fixture.WinFormsHandle, "Enable the button below");
+        var btnRef = FindRefByName(_fixture.WinFormsHandle, "Conditional Button");
+        Assert.NotNull(cbRef);
+        Assert.NotNull(btnRef);
+
+        // Verify button is initially disabled
+        Assert.Contains("disabled", snapshot1.Split('\n').First(l => l.Contains("Conditional Button")));
+
+        // Click the checkbox to enable the button
+        var clickTool = new ClickTool(_fixture.Elements);
+        await CallTool(clickTool, new { @ref = cbRef });
+        await Task.Delay(500);
+
+        // Re-snapshot to check updated state
+        var snapshot2 = builder.BuildSnapshot(_fixture.WinFormsHandle, window);
+        _output.WriteLine("\nAfter checkbox click:");
+        foreach (var line in snapshot2.Split('\n'))
+        {
+            if (line.Contains("Conditional") || line.Contains("Enable"))
+                _output.WriteLine(line);
+        }
+
+        var conditionalLine = snapshot2.Split('\n').First(l => l.Contains("Conditional Button"));
+        _output.WriteLine($"\nConditional Button line: {conditionalLine}");
+
+        // Button should now be enabled (no [disabled] tag)
+        Assert.DoesNotContain("disabled", conditionalLine);
+
+        // Clean up: uncheck the checkbox
+        await CallTool(clickTool, new { @ref = cbRef });
+    }
+
+    [Fact]
+    public async Task Wpf_Click_Button_Invoke()
+    {
+        var buttonRef = FindRefByName(_fixture.WpfHandle, "Click Me");
+        Assert.NotNull(buttonRef);
+        _output.WriteLine($"Click Me button ref: {buttonRef}");
+
+        var tool = new ClickTool(_fixture.Elements);
+        var result = await CallTool(tool, new { @ref = buttonRef });
+        Assert.Contains("Invoked", result);
+    }
+}

--- a/tests/FlaUI.Mcp.IntegrationTests/ClickTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/ClickTests.cs
@@ -102,10 +102,18 @@ public class ClickTests
         // Click the checkbox to enable the button
         var clickTool = new ClickTool(_fixture.Elements);
         await CallTool(clickTool, new { @ref = cbRef });
-        await Task.Delay(500);
 
-        // Re-snapshot to check updated state
-        var snapshot2 = builder.BuildSnapshot(_fixture.WinFormsHandle, window);
+        // Poll for the button to become enabled instead of using a fixed delay
+        string snapshot2 = "";
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < 5000)
+        {
+            await Task.Delay(100);
+            snapshot2 = builder.BuildSnapshot(_fixture.WinFormsHandle, window);
+            var line = snapshot2.Split('\n').FirstOrDefault(l => l.Contains("Conditional Button"));
+            if (line != null && !line.Contains("disabled"))
+                break;
+        }
         _output.WriteLine("\nAfter checkbox click:");
         foreach (var line in snapshot2.Split('\n'))
         {

--- a/tests/FlaUI.Mcp.IntegrationTests/ClickTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/ClickTests.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using PlaywrightWindows.Mcp.Core;
 using PlaywrightWindows.Mcp.Tools;
 using Xunit.Abstractions;
 
@@ -53,10 +52,8 @@ public class ClickTests
     [Fact]
     public async Task WinForms_EnabledStateChanges_AfterCheckboxClick()
     {
-        // First snapshot to find refs
-        var builder = new SnapshotBuilder(_fixture.Elements);
-        var window = _fixture.GetWinFormsWindow()!;
-        var snapshot1 = builder.BuildSnapshot(_fixture.WinFormsHandle, window);
+        // Take one snapshot and find both refs from it
+        var snapshot1 = _fixture.TakeSnapshot(_fixture.WinFormsHandle);
         _output.WriteLine("Initial snapshot (partial):");
         foreach (var line in snapshot1.Split('\n'))
         {
@@ -64,8 +61,7 @@ public class ClickTests
                 _output.WriteLine(line);
         }
 
-        // Find the checkbox and button refs
-        var cbRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Enable the button below");
+        var cbRef = TestAppFixture.FindRefInSnapshot(snapshot1, "Enable the button below");
         Assert.NotNull(cbRef);
 
         // Verify button is initially disabled
@@ -81,7 +77,7 @@ public class ClickTests
         while (sw.ElapsedMilliseconds < 5000)
         {
             await Task.Delay(100);
-            snapshot2 = builder.BuildSnapshot(_fixture.WinFormsHandle, window);
+            snapshot2 = _fixture.TakeSnapshot(_fixture.WinFormsHandle);
             var line = snapshot2.Split('\n').FirstOrDefault(l => l.Contains("Conditional Button"));
             if (line != null && !line.Contains("disabled"))
                 break;

--- a/tests/FlaUI.Mcp.IntegrationTests/ClickTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/ClickTests.cs
@@ -1,5 +1,4 @@
-using System.Text.Json;
-using PlaywrightWindows.Mcp;
+using System.Diagnostics;
 using PlaywrightWindows.Mcp.Core;
 using PlaywrightWindows.Mcp.Tools;
 using Xunit.Abstractions;
@@ -21,59 +20,34 @@ public class ClickTests
         _output = output;
     }
 
-    private async Task<string> CallTool(ToolBase tool, object args)
-    {
-        var json = JsonSerializer.Serialize(args, McpProtocol.JsonOptions);
-        var element = JsonSerializer.Deserialize<JsonElement>(json);
-        var result = await tool.ExecuteAsync(element);
-        var text = result.Content.FirstOrDefault()?.Text ?? "";
-        _output.WriteLine($"Result: {text}");
-        return text;
-    }
-
-    private string? FindRefByName(string handle, string name)
-    {
-        var builder = new SnapshotBuilder(_fixture.Elements);
-        var window = _fixture.Session.GetWindow(handle)!;
-        var snapshot = builder.BuildSnapshot(handle, window);
-        // Parse snapshot to find ref for element with given name
-        foreach (var line in snapshot.Split('\n'))
-        {
-            if (line.Contains($"\"{name}\"") && line.Contains("[ref="))
-            {
-                var refStart = line.IndexOf("[ref=") + 5;
-                var refEnd = line.IndexOf("]", refStart);
-                return line[refStart..refEnd];
-            }
-        }
-        return null;
-    }
-
     [Fact]
     public async Task WinForms_Click_Button_Invoke()
     {
-        var buttonRef = FindRefByName(_fixture.WinFormsHandle, "Click Me");
+        var buttonRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Click Me");
         Assert.NotNull(buttonRef);
         _output.WriteLine($"Click Me button ref: {buttonRef}");
 
         var tool = new ClickTool(_fixture.Elements);
-        var result = await CallTool(tool, new { @ref = buttonRef });
+        var result = await _fixture.CallTool(tool, new { @ref = buttonRef });
+        _output.WriteLine($"Result: {result}");
         Assert.Contains("Invoked", result);
     }
 
     [Fact]
     public async Task WinForms_Click_Checkbox_Toggle()
     {
-        var cbRef = FindRefByName(_fixture.WinFormsHandle, "Enable the button below");
+        var cbRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Enable the button below");
         Assert.NotNull(cbRef);
 
         var tool = new ClickTool(_fixture.Elements);
-        var result = await CallTool(tool, new { @ref = cbRef });
+        var result = await _fixture.CallTool(tool, new { @ref = cbRef });
+        _output.WriteLine($"Result: {result}");
         // WinForms checkboxes support InvokePattern, so ClickTool uses Invoke (not Toggle)
-        Assert.True(result.Contains("Invoked") || result.Contains("Toggled"), $"Expected Invoked or Toggled, got: {result}");
+        Assert.True(result.Contains("Invoked") || result.Contains("Toggled"),
+            $"Expected Invoked or Toggled, got: {result}");
 
         // Toggle back to original state
-        await CallTool(tool, new { @ref = cbRef });
+        await _fixture.CallTool(tool, new { @ref = cbRef });
     }
 
     [Fact]
@@ -91,21 +65,19 @@ public class ClickTests
         }
 
         // Find the checkbox and button refs
-        var cbRef = FindRefByName(_fixture.WinFormsHandle, "Enable the button below");
-        var btnRef = FindRefByName(_fixture.WinFormsHandle, "Conditional Button");
+        var cbRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Enable the button below");
         Assert.NotNull(cbRef);
-        Assert.NotNull(btnRef);
 
         // Verify button is initially disabled
         Assert.Contains("disabled", snapshot1.Split('\n').First(l => l.Contains("Conditional Button")));
 
         // Click the checkbox to enable the button
         var clickTool = new ClickTool(_fixture.Elements);
-        await CallTool(clickTool, new { @ref = cbRef });
+        await _fixture.CallTool(clickTool, new { @ref = cbRef });
 
-        // Poll for the button to become enabled instead of using a fixed delay
+        // Poll for the button to become enabled
         string snapshot2 = "";
-        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var sw = Stopwatch.StartNew();
         while (sw.ElapsedMilliseconds < 5000)
         {
             await Task.Delay(100);
@@ -128,18 +100,19 @@ public class ClickTests
         Assert.DoesNotContain("disabled", conditionalLine);
 
         // Clean up: uncheck the checkbox
-        await CallTool(clickTool, new { @ref = cbRef });
+        await _fixture.CallTool(clickTool, new { @ref = cbRef });
     }
 
     [Fact]
     public async Task Wpf_Click_Button_Invoke()
     {
-        var buttonRef = FindRefByName(_fixture.WpfHandle, "Click Me");
+        var buttonRef = _fixture.FindRefByName(_fixture.WpfHandle, "Click Me");
         Assert.NotNull(buttonRef);
         _output.WriteLine($"Click Me button ref: {buttonRef}");
 
         var tool = new ClickTool(_fixture.Elements);
-        var result = await CallTool(tool, new { @ref = buttonRef });
+        var result = await _fixture.CallTool(tool, new { @ref = buttonRef });
+        _output.WriteLine($"Result: {result}");
         Assert.Contains("Invoked", result);
     }
 }

--- a/tests/FlaUI.Mcp.IntegrationTests/FlaUI.Mcp.IntegrationTests.csproj
+++ b/tests/FlaUI.Mcp.IntegrationTests/FlaUI.Mcp.IntegrationTests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UseWindowsForms>true</UseWindowsForms>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FlaUI.Mcp\FlaUI.Mcp.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/FlaUI.Mcp.IntegrationTests/SnapshotTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/SnapshotTests.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+using PlaywrightWindows.Mcp;
+using PlaywrightWindows.Mcp.Core;
+using PlaywrightWindows.Mcp.Tools;
+using Xunit.Abstractions;
+
+namespace FlaUI.Mcp.IntegrationTests;
+
+/// <summary>
+/// Tests for windows_snapshot tool using the WinForms and WPF test apps.
+/// </summary>
+[Collection("TestApps")]
+public class SnapshotTests
+{
+    private readonly TestAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public SnapshotTests(TestAppFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    [Fact]
+    public void WinFormsApp_IsRunning()
+    {
+        Assert.NotEmpty(_fixture.WinFormsHandle);
+        var window = _fixture.GetWinFormsWindow();
+        Assert.NotNull(window);
+        _output.WriteLine($"WinForms window: {window.Title} (handle: {_fixture.WinFormsHandle})");
+    }
+
+    [Fact]
+    public void WpfApp_IsRunning()
+    {
+        Assert.NotEmpty(_fixture.WpfHandle);
+        var window = _fixture.GetWpfWindow();
+        Assert.NotNull(window);
+        _output.WriteLine($"WPF window: {window.Title} (handle: {_fixture.WpfHandle})");
+    }
+
+    [Fact]
+    public void WinForms_Snapshot_ContainsTabControl()
+    {
+        var builder = new SnapshotBuilder(_fixture.Elements);
+        var snapshot = builder.BuildSnapshot(_fixture.WinFormsHandle, _fixture.GetWinFormsWindow()!);
+        _output.WriteLine(snapshot);
+
+        Assert.Contains("Buttons", snapshot);
+        Assert.Contains("Forms", snapshot);
+        Assert.Contains("Grid", snapshot);
+        Assert.Contains("Trees", snapshot);
+        Assert.Contains("Dialogs", snapshot);
+    }
+
+    [Fact]
+    public void Wpf_Snapshot_ContainsTabControl()
+    {
+        var builder = new SnapshotBuilder(_fixture.Elements);
+        var snapshot = builder.BuildSnapshot(_fixture.WpfHandle, _fixture.GetWpfWindow()!);
+        _output.WriteLine(snapshot);
+
+        Assert.Contains("Buttons", snapshot);
+        Assert.Contains("Forms", snapshot);
+        Assert.Contains("Grid", snapshot);
+        Assert.Contains("Trees", snapshot);
+    }
+
+    [Fact]
+    public void WinForms_Snapshot_ContainsButtons()
+    {
+        var builder = new SnapshotBuilder(_fixture.Elements);
+        var snapshot = builder.BuildSnapshot(_fixture.WinFormsHandle, _fixture.GetWinFormsWindow()!);
+
+        Assert.Contains("Click Me", snapshot);
+        Assert.Contains("Conditional Button", snapshot);
+        // Note: Conditional Button may or may not be disabled depending on test ordering
+        // (the EnabledStateChanges test toggles it). We just verify the elements exist.
+    }
+
+    [Fact]
+    public async Task WinForms_Snapshot_ContainsGridData()
+    {
+        // Navigate to Grid tab first — WinForms only shows active tab content
+        var builder = new SnapshotBuilder(_fixture.Elements);
+        var snapshot = builder.BuildSnapshot(_fixture.WinFormsHandle, _fixture.GetWinFormsWindow()!);
+        string? gridTabRef = null;
+        foreach (var line in snapshot.Split('\n'))
+        {
+            // Find the "Grid" tab (not the grid itself)
+            if (line.Contains("\"Grid\"") && line.Contains("tab ") && line.Contains("[ref="))
+            {
+                var s = line.IndexOf("[ref=") + 5;
+                gridTabRef = line[s..line.IndexOf("]", s)];
+                break;
+            }
+        }
+
+        if (gridTabRef != null)
+        {
+            var clickTool = new ClickTool(_fixture.Elements);
+            var json = JsonSerializer.Serialize(new { @ref = gridTabRef }, McpProtocol.JsonOptions);
+            await clickTool.ExecuteAsync(JsonSerializer.Deserialize<JsonElement>(json));
+            await Task.Delay(500);
+        }
+
+        // Re-snapshot after navigating to Grid tab
+        var snapshot2 = builder.BuildSnapshot(_fixture.WinFormsHandle, _fixture.GetWinFormsWindow()!);
+        _output.WriteLine(snapshot2.Substring(0, Math.Min(2000, snapshot2.Length)));
+
+        Assert.Contains("Test Data", snapshot2);
+    }
+}

--- a/tests/FlaUI.Mcp.IntegrationTests/SnapshotTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/SnapshotTests.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-using PlaywrightWindows.Mcp;
 using PlaywrightWindows.Mcp.Core;
 using PlaywrightWindows.Mcp.Tools;
 using Xunit.Abstractions;
@@ -82,32 +80,26 @@ public class SnapshotTests
     public async Task WinForms_Snapshot_ContainsGridData()
     {
         // Navigate to Grid tab first — WinForms only shows active tab content
-        var builder = new SnapshotBuilder(_fixture.Elements);
-        var snapshot = builder.BuildSnapshot(_fixture.WinFormsHandle, _fixture.GetWinFormsWindow()!);
-        string? gridTabRef = null;
-        foreach (var line in snapshot.Split('\n'))
+        var snapshot = _fixture.TakeSnapshot(_fixture.WinFormsHandle);
+        var gridTabRef = TestAppFixture.FindRefInSnapshot(snapshot, "Grid");
+
+        Assert.NotNull(gridTabRef);
+
+        var clickTool = new ClickTool(_fixture.Elements);
+        await _fixture.CallTool(clickTool, new { @ref = gridTabRef });
+
+        // Poll for grid content to appear after tab switch
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        string snapshot2 = "";
+        while (sw.ElapsedMilliseconds < 5000)
         {
-            // Find the "Grid" tab (not the grid itself)
-            if (line.Contains("\"Grid\"") && line.Contains("tab ") && line.Contains("[ref="))
-            {
-                var s = line.IndexOf("[ref=") + 5;
-                gridTabRef = line[s..line.IndexOf("]", s)];
+            await Task.Delay(100);
+            snapshot2 = _fixture.TakeSnapshot(_fixture.WinFormsHandle);
+            if (snapshot2.Contains("Test Data"))
                 break;
-            }
         }
 
-        if (gridTabRef != null)
-        {
-            var clickTool = new ClickTool(_fixture.Elements);
-            var json = JsonSerializer.Serialize(new { @ref = gridTabRef }, McpProtocol.JsonOptions);
-            await clickTool.ExecuteAsync(JsonSerializer.Deserialize<JsonElement>(json));
-            await Task.Delay(500);
-        }
-
-        // Re-snapshot after navigating to Grid tab
-        var snapshot2 = builder.BuildSnapshot(_fixture.WinFormsHandle, _fixture.GetWinFormsWindow()!);
-        _output.WriteLine(snapshot2.Substring(0, Math.Min(2000, snapshot2.Length)));
-
+        _output.WriteLine(snapshot2[..Math.Min(2000, snapshot2.Length)]);
         Assert.Contains("Test Data", snapshot2);
     }
 }

--- a/tests/FlaUI.Mcp.IntegrationTests/SnapshotTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/SnapshotTests.cs
@@ -65,15 +65,21 @@ public class SnapshotTests
     }
 
     [Fact]
-    public void WinForms_Snapshot_ContainsButtons()
+    public async Task WinForms_Snapshot_ContainsButtons()
     {
-        var builder = new SnapshotBuilder(_fixture.Elements);
-        var snapshot = builder.BuildSnapshot(_fixture.WinFormsHandle, _fixture.GetWinFormsWindow()!);
+        // Navigate to Buttons tab first — another test may have switched tabs
+        var snapshot = _fixture.TakeSnapshot(_fixture.WinFormsHandle);
+        var tabRef = TestAppFixture.FindRefInSnapshot(snapshot, "Buttons");
+        if (tabRef != null)
+        {
+            var clickTool = new ClickTool(_fixture.Elements);
+            await _fixture.CallTool(clickTool, new { @ref = tabRef });
+            await Task.Delay(100);
+        }
 
-        Assert.Contains("Click Me", snapshot);
-        Assert.Contains("Conditional Button", snapshot);
-        // Note: Conditional Button may or may not be disabled depending on test ordering
-        // (the EnabledStateChanges test toggles it). We just verify the elements exist.
+        var snapshot2 = _fixture.TakeSnapshot(_fixture.WinFormsHandle);
+        Assert.Contains("Click Me", snapshot2);
+        Assert.Contains("Conditional Button", snapshot2);
     }
 
     [Fact]

--- a/tests/FlaUI.Mcp.IntegrationTests/TestAppFixture.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/TestAppFixture.cs
@@ -1,0 +1,106 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Definitions;
+using PlaywrightWindows.Mcp.Core;
+
+namespace FlaUI.Mcp.IntegrationTests;
+
+/// <summary>
+/// Shared fixture that launches the WinForms and WPF test apps once per test collection.
+/// Provides SessionManager and ElementRegistry for all tests to share.
+/// </summary>
+public class TestAppFixture : IDisposable
+{
+    public SessionManager Session { get; }
+    public ElementRegistry Elements { get; }
+
+    public string WinFormsHandle { get; private set; } = "";
+    public string WpfHandle { get; private set; } = "";
+
+    private Process? _winFormsProcess;
+    private Process? _wpfProcess;
+
+    public TestAppFixture()
+    {
+        Session = new SessionManager();
+        Elements = new ElementRegistry();
+
+        _winFormsProcess = LaunchTestApp(FindTestAppPath("WinFormsTestApp"));
+        _wpfProcess = LaunchTestApp(FindTestAppPath("WpfTestApp"));
+
+        // Wait for windows to appear and register them
+        Thread.Sleep(3000);
+
+        var desktop = Session.Automation.GetDesktop();
+        var windows = desktop.FindAllChildren(cf => cf.ByControlType(ControlType.Window));
+        foreach (var w in windows)
+        {
+            var win = w.AsWindow();
+            if (win?.Title == "FlaUI-MCP Test App")
+            {
+                WinFormsHandle = Session.RegisterWindow(win);
+            }
+            else if (win?.Title == "FlaUI-MCP WPF Test App")
+            {
+                WpfHandle = Session.RegisterWindow(win);
+            }
+        }
+    }
+
+    private static Process? LaunchTestApp(string? path)
+    {
+        if (path == null) return null;
+
+        var psi = new ProcessStartInfo(path) { UseShellExecute = true };
+        return Process.Start(psi);
+    }
+
+    private static string? FindTestAppPath(string appName)
+    {
+        // Search for the built test app executable
+        // Look relative to the integration test assembly location
+        var baseDir = AppContext.BaseDirectory;
+
+        // Walk up to find the repo root (contains src/)
+        var dir = new DirectoryInfo(baseDir);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "src")))
+        {
+            dir = dir.Parent;
+        }
+
+        if (dir == null) return null;
+
+        // Look for the test app in its build output
+        var searchPaths = new[]
+        {
+            // WinForms app (net481)
+            Path.Combine(dir.FullName, "tests", "TestApps", appName, "bin", "Debug", "net481", $"{appName}.exe"),
+            // WPF app (net8.0-windows)
+            Path.Combine(dir.FullName, "tests", "TestApps", appName, "bin", "Debug", "net8.0-windows", $"{appName}.exe"),
+            // Release builds
+            Path.Combine(dir.FullName, "tests", "TestApps", appName, "bin", "Release", "net481", $"{appName}.exe"),
+            Path.Combine(dir.FullName, "tests", "TestApps", appName, "bin", "Release", "net8.0-windows", $"{appName}.exe"),
+        };
+
+        return searchPaths.FirstOrDefault(File.Exists);
+    }
+
+    public Window? GetWinFormsWindow() => Session.GetWindow(WinFormsHandle);
+    public Window? GetWpfWindow() => Session.GetWindow(WpfHandle);
+
+    public void Dispose()
+    {
+        try { _winFormsProcess?.Kill(); } catch { }
+        try { _wpfProcess?.Kill(); } catch { }
+        Session.Dispose();
+    }
+}
+
+/// <summary>
+/// Collection definition so all test classes share the same fixture (same app instances).
+/// </summary>
+[CollectionDefinition("TestApps")]
+public class TestAppCollection : ICollectionFixture<TestAppFixture>
+{
+}

--- a/tests/FlaUI.Mcp.IntegrationTests/TestAppFixture.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/TestAppFixture.cs
@@ -1,21 +1,26 @@
 using System.Diagnostics;
+using System.Text.Json;
 using FlaUI.Core.AutomationElements;
 using FlaUI.Core.Definitions;
+using PlaywrightWindows.Mcp;
 using PlaywrightWindows.Mcp.Core;
+using PlaywrightWindows.Mcp.Tools;
+using Xunit.Abstractions;
 
 namespace FlaUI.Mcp.IntegrationTests;
 
 /// <summary>
 /// Shared fixture that launches the WinForms and WPF test apps once per test collection.
 /// Provides SessionManager and ElementRegistry for all tests to share.
+/// Implements IAsyncLifetime for proper async setup/teardown.
 /// </summary>
-public class TestAppFixture : IDisposable
+public class TestAppFixture : IAsyncLifetime
 {
     private const int WindowPollIntervalMs = 250;
     private const int WindowPollTimeoutMs = 15000;
 
-    public SessionManager Session { get; }
-    public ElementRegistry Elements { get; }
+    public SessionManager Session { get; } = new();
+    public ElementRegistry Elements { get; } = new();
 
     public string WinFormsHandle { get; private set; } = "";
     public string WpfHandle { get; private set; } = "";
@@ -23,20 +28,24 @@ public class TestAppFixture : IDisposable
     private Process? _winFormsProcess;
     private Process? _wpfProcess;
 
-    public TestAppFixture()
+    public async Task InitializeAsync()
     {
-        Session = new SessionManager();
-        Elements = new ElementRegistry();
+        var winFormsPath = FindTestAppPath("WinFormsTestApp")
+            ?? throw new Exception(
+                "WinFormsTestApp not found. Build it first: dotnet build tests/TestApps/WinFormsTestApp");
+        var wpfPath = FindTestAppPath("WpfTestApp")
+            ?? throw new Exception(
+                "WpfTestApp not found. Build it first: dotnet build tests/TestApps/WpfTestApp");
 
-        _winFormsProcess = LaunchTestApp(FindTestAppPath("WinFormsTestApp"));
-        _wpfProcess = LaunchTestApp(FindTestAppPath("WpfTestApp"));
+        _winFormsProcess = LaunchTestApp(winFormsPath);
+        _wpfProcess = LaunchTestApp(wpfPath);
 
         // Poll for both windows to appear
         var sw = Stopwatch.StartNew();
         while (sw.ElapsedMilliseconds < WindowPollTimeoutMs
                && (WinFormsHandle == "" || WpfHandle == ""))
         {
-            Thread.Sleep(WindowPollIntervalMs);
+            await Task.Delay(WindowPollIntervalMs);
 
             var desktop = Session.Automation.GetDesktop();
             var windows = desktop.FindAllChildren(cf => cf.ByControlType(ControlType.Window));
@@ -53,20 +62,29 @@ public class TestAppFixture : IDisposable
                 }
             }
         }
+
+        if (WinFormsHandle == "")
+            throw new Exception("Timed out waiting for WinForms test app window.");
+        if (WpfHandle == "")
+            throw new Exception("Timed out waiting for WPF test app window.");
     }
 
-    private static Process? LaunchTestApp(string? path)
+    public Task DisposeAsync()
     {
-        if (path == null) return null;
+        CloseProcess(_winFormsProcess);
+        CloseProcess(_wpfProcess);
+        Session.Dispose();
+        return Task.CompletedTask;
+    }
 
+    private static Process? LaunchTestApp(string path)
+    {
         var psi = new ProcessStartInfo(path) { UseShellExecute = true };
         return Process.Start(psi);
     }
 
     private static string? FindTestAppPath(string appName)
     {
-        // Search for the built test app executable
-        // Look relative to the integration test assembly location
         var baseDir = AppContext.BaseDirectory;
 
         // Walk up to find the repo root (contains src/)
@@ -78,14 +96,10 @@ public class TestAppFixture : IDisposable
 
         if (dir == null) return null;
 
-        // Look for the test app in its build output
         var searchPaths = new[]
         {
-            // WinForms app (net481)
             Path.Combine(dir.FullName, "tests", "TestApps", appName, "bin", "Debug", "net481", $"{appName}.exe"),
-            // WPF app (net8.0-windows)
             Path.Combine(dir.FullName, "tests", "TestApps", appName, "bin", "Debug", "net8.0-windows", $"{appName}.exe"),
-            // Release builds
             Path.Combine(dir.FullName, "tests", "TestApps", appName, "bin", "Release", "net481", $"{appName}.exe"),
             Path.Combine(dir.FullName, "tests", "TestApps", appName, "bin", "Release", "net8.0-windows", $"{appName}.exe"),
         };
@@ -96,11 +110,37 @@ public class TestAppFixture : IDisposable
     public Window? GetWinFormsWindow() => Session.GetWindow(WinFormsHandle);
     public Window? GetWpfWindow() => Session.GetWindow(WpfHandle);
 
-    public void Dispose()
+    /// <summary>
+    /// Call an MCP tool with the given arguments and return the text result.
+    /// Shared helper to avoid duplication across test classes.
+    /// </summary>
+    public async Task<string> CallTool(ToolBase tool, object args)
     {
-        CloseProcess(_winFormsProcess);
-        CloseProcess(_wpfProcess);
-        Session.Dispose();
+        var json = JsonSerializer.Serialize(args, McpProtocol.JsonOptions);
+        var element = JsonSerializer.Deserialize<JsonElement>(json);
+        var result = await tool.ExecuteAsync(element);
+        return result.Content.FirstOrDefault()?.Text ?? "";
+    }
+
+    /// <summary>
+    /// Find an element ref by name in the snapshot of the given window.
+    /// Shared helper to avoid duplication across test classes.
+    /// </summary>
+    public string? FindRefByName(string handle, string name)
+    {
+        var builder = new SnapshotBuilder(Elements);
+        var window = Session.GetWindow(handle)!;
+        var snapshot = builder.BuildSnapshot(handle, window);
+        foreach (var line in snapshot.Split('\n'))
+        {
+            if (line.Contains($"\"{name}\"") && line.Contains("[ref="))
+            {
+                var refStart = line.IndexOf("[ref=") + 5;
+                var refEnd = line.IndexOf("]", refStart);
+                return line[refStart..refEnd];
+            }
+        }
+        return null;
     }
 
     private static void CloseProcess(Process? process)

--- a/tests/FlaUI.Mcp.IntegrationTests/TestAppFixture.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/TestAppFixture.cs
@@ -5,7 +5,6 @@ using FlaUI.Core.Definitions;
 using PlaywrightWindows.Mcp;
 using PlaywrightWindows.Mcp.Core;
 using PlaywrightWindows.Mcp.Tools;
-using Xunit.Abstractions;
 
 namespace FlaUI.Mcp.IntegrationTests;
 
@@ -123,14 +122,32 @@ public class TestAppFixture : IAsyncLifetime
     }
 
     /// <summary>
-    /// Find an element ref by name in the snapshot of the given window.
-    /// Shared helper to avoid duplication across test classes.
+    /// Take a snapshot of a window and return the text.
     /// </summary>
-    public string? FindRefByName(string handle, string name)
+    public string TakeSnapshot(string handle)
     {
         var builder = new SnapshotBuilder(Elements);
         var window = Session.GetWindow(handle)!;
-        var snapshot = builder.BuildSnapshot(handle, window);
+        return builder.BuildSnapshot(handle, window);
+    }
+
+    /// <summary>
+    /// Find an element ref by name in the snapshot of the given window.
+    /// Takes a fresh snapshot each time — use the overload accepting a
+    /// pre-built snapshot when multiple lookups are needed.
+    /// </summary>
+    public string? FindRefByName(string handle, string name)
+    {
+        var snapshot = TakeSnapshot(handle);
+        return FindRefInSnapshot(snapshot, name);
+    }
+
+    /// <summary>
+    /// Find an element ref by name in a pre-built snapshot string.
+    /// Use this when making multiple lookups against the same snapshot.
+    /// </summary>
+    public static string? FindRefInSnapshot(string snapshot, string name)
+    {
         foreach (var line in snapshot.Split('\n'))
         {
             if (line.Contains($"\"{name}\"") && line.Contains("[ref="))

--- a/tests/FlaUI.Mcp.IntegrationTests/TestAppFixture.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/TestAppFixture.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using FlaUI.Core.AutomationElements;
 using FlaUI.Core.Definitions;
 using PlaywrightWindows.Mcp.Core;
@@ -12,6 +11,9 @@ namespace FlaUI.Mcp.IntegrationTests;
 /// </summary>
 public class TestAppFixture : IDisposable
 {
+    private const int WindowPollIntervalMs = 250;
+    private const int WindowPollTimeoutMs = 15000;
+
     public SessionManager Session { get; }
     public ElementRegistry Elements { get; }
 
@@ -29,21 +31,26 @@ public class TestAppFixture : IDisposable
         _winFormsProcess = LaunchTestApp(FindTestAppPath("WinFormsTestApp"));
         _wpfProcess = LaunchTestApp(FindTestAppPath("WpfTestApp"));
 
-        // Wait for windows to appear and register them
-        Thread.Sleep(3000);
-
-        var desktop = Session.Automation.GetDesktop();
-        var windows = desktop.FindAllChildren(cf => cf.ByControlType(ControlType.Window));
-        foreach (var w in windows)
+        // Poll for both windows to appear
+        var sw = Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < WindowPollTimeoutMs
+               && (WinFormsHandle == "" || WpfHandle == ""))
         {
-            var win = w.AsWindow();
-            if (win?.Title == "FlaUI-MCP Test App")
+            Thread.Sleep(WindowPollIntervalMs);
+
+            var desktop = Session.Automation.GetDesktop();
+            var windows = desktop.FindAllChildren(cf => cf.ByControlType(ControlType.Window));
+            foreach (var w in windows)
             {
-                WinFormsHandle = Session.RegisterWindow(win);
-            }
-            else if (win?.Title == "FlaUI-MCP WPF Test App")
-            {
-                WpfHandle = Session.RegisterWindow(win);
+                var win = w.AsWindow();
+                if (win?.Title == "FlaUI-MCP Test App" && WinFormsHandle == "")
+                {
+                    WinFormsHandle = Session.RegisterWindow(win);
+                }
+                else if (win?.Title == "FlaUI-MCP WPF Test App" && WpfHandle == "")
+                {
+                    WpfHandle = Session.RegisterWindow(win);
+                }
             }
         }
     }
@@ -91,9 +98,26 @@ public class TestAppFixture : IDisposable
 
     public void Dispose()
     {
-        try { _winFormsProcess?.Kill(); } catch { }
-        try { _wpfProcess?.Kill(); } catch { }
+        CloseProcess(_winFormsProcess);
+        CloseProcess(_wpfProcess);
         Session.Dispose();
+    }
+
+    private static void CloseProcess(Process? process)
+    {
+        if (process == null || process.HasExited) return;
+        try
+        {
+            process.CloseMainWindow();
+            if (!process.WaitForExit(3000))
+            {
+                process.Kill();
+            }
+        }
+        catch
+        {
+            try { process.Kill(); } catch { }
+        }
     }
 }
 

--- a/tests/FlaUI.Mcp.IntegrationTests/TextAndValueTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/TextAndValueTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using PlaywrightWindows.Mcp.Tools;
 using Xunit.Abstractions;
 
@@ -18,25 +19,35 @@ public class TextAndValueTests
         _output = output;
     }
 
+    /// <summary>
+    /// Navigate to a tab and poll until an expected element appears.
+    /// Returns the ref of the expected element.
+    /// </summary>
+    private async Task<string> NavigateToTabAndFind(string windowHandle, string tabName, string elementName)
+    {
+        var tabRef = _fixture.FindRefByName(windowHandle, tabName);
+        Assert.NotNull(tabRef);
+
+        var clickTool = new ClickTool(_fixture.Elements);
+        await _fixture.CallTool(clickTool, new { @ref = tabRef });
+
+        // Poll for the element to appear after tab switch
+        var sw = Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < 5000)
+        {
+            await Task.Delay(100);
+            var found = _fixture.FindRefByName(windowHandle, elementName);
+            if (found != null) return found;
+        }
+
+        Assert.Fail($"Element \"{elementName}\" not found after navigating to \"{tabName}\" tab.");
+        return ""; // unreachable
+    }
+
     [Fact]
     public async Task WinForms_GetText_ReadOnlyField()
     {
-        // Navigate to Forms tab first by finding and clicking it
-        var tabRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Forms");
-        if (tabRef != null)
-        {
-            var clickTool = new ClickTool(_fixture.Elements);
-            await _fixture.CallTool(clickTool, new { @ref = tabRef });
-            await Task.Delay(300);
-        }
-
-        // Re-snapshot after tab switch
-        var resultRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Result");
-        if (resultRef == null)
-        {
-            _output.WriteLine("SKIP: Could not find Result text box");
-            return;
-        }
+        var resultRef = await NavigateToTabAndFind(_fixture.WinFormsHandle, "Forms", "Result");
 
         var tool = new GetTextTool(_fixture.Elements);
         var text = await _fixture.CallTool(tool, new { @ref = resultRef });
@@ -47,21 +58,7 @@ public class TextAndValueTests
     [Fact]
     public async Task WinForms_TypeAndGetText()
     {
-        // Navigate to Forms tab
-        var tabRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Forms");
-        if (tabRef != null)
-        {
-            var clickTool = new ClickTool(_fixture.Elements);
-            await _fixture.CallTool(clickTool, new { @ref = tabRef });
-            await Task.Delay(300);
-        }
-
-        var nameRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Name");
-        if (nameRef == null)
-        {
-            _output.WriteLine("SKIP: Could not find Name text box");
-            return;
-        }
+        var nameRef = await NavigateToTabAndFind(_fixture.WinFormsHandle, "Forms", "Name");
 
         // Fill the name field
         var fillTool = new FillTool(_fixture.Elements);
@@ -81,21 +78,7 @@ public class TextAndValueTests
     [Fact]
     public async Task Wpf_GetText_ReadOnlyField()
     {
-        // Navigate to Forms tab
-        var tabRef = _fixture.FindRefByName(_fixture.WpfHandle, "Forms");
-        if (tabRef != null)
-        {
-            var clickTool = new ClickTool(_fixture.Elements);
-            await _fixture.CallTool(clickTool, new { @ref = tabRef });
-            await Task.Delay(300);
-        }
-
-        var resultRef = _fixture.FindRefByName(_fixture.WpfHandle, "Result");
-        if (resultRef == null)
-        {
-            _output.WriteLine("SKIP: Could not find Result text box");
-            return;
-        }
+        var resultRef = await NavigateToTabAndFind(_fixture.WpfHandle, "Forms", "Result");
 
         var tool = new GetTextTool(_fixture.Elements);
         var text = await _fixture.CallTool(tool, new { @ref = resultRef });

--- a/tests/FlaUI.Mcp.IntegrationTests/TextAndValueTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/TextAndValueTests.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using PlaywrightWindows.Mcp;
+using PlaywrightWindows.Mcp.Core;
+using PlaywrightWindows.Mcp.Tools;
+using Xunit.Abstractions;
+
+namespace FlaUI.Mcp.IntegrationTests;
+
+/// <summary>
+/// Tests for windows_get_text, windows_type, and windows_fill tools.
+/// </summary>
+[Collection("TestApps")]
+public class TextAndValueTests
+{
+    private readonly TestAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public TextAndValueTests(TestAppFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    private async Task<string> CallTool(ToolBase tool, object args)
+    {
+        var json = JsonSerializer.Serialize(args, McpProtocol.JsonOptions);
+        var element = JsonSerializer.Deserialize<JsonElement>(json);
+        var result = await tool.ExecuteAsync(element);
+        return result.Content.FirstOrDefault()?.Text ?? "";
+    }
+
+    private string? FindRefByName(string handle, string name)
+    {
+        var builder = new SnapshotBuilder(_fixture.Elements);
+        var window = _fixture.Session.GetWindow(handle)!;
+        builder.BuildSnapshot(handle, window);
+        // Search snapshot lines for the name
+        var snapshot = builder.BuildSnapshot(handle, window);
+        foreach (var line in snapshot.Split('\n'))
+        {
+            if (line.Contains($"\"{name}\"") && line.Contains("[ref="))
+            {
+                var refStart = line.IndexOf("[ref=") + 5;
+                var refEnd = line.IndexOf("]", refStart);
+                return line[refStart..refEnd];
+            }
+        }
+        return null;
+    }
+
+    [Fact]
+    public async Task WinForms_GetText_ReadOnlyField()
+    {
+        // Navigate to Forms tab first by finding and clicking it
+        var tabRef = FindRefByName(_fixture.WinFormsHandle, "Forms");
+        if (tabRef != null)
+        {
+            var clickTool = new ClickTool(_fixture.Elements);
+            await CallTool(clickTool, new { @ref = tabRef });
+            await Task.Delay(300);
+        }
+
+        // Re-snapshot after tab switch
+        var resultRef = FindRefByName(_fixture.WinFormsHandle, "Result");
+        if (resultRef == null)
+        {
+            _output.WriteLine("SKIP: Could not find Result text box");
+            return;
+        }
+
+        var tool = new GetTextTool(_fixture.Elements);
+        var text = await CallTool(tool, new { @ref = resultRef });
+        _output.WriteLine($"Result text: '{text}'");
+        Assert.Equal("Computed value here", text);
+    }
+
+    [Fact]
+    public async Task WinForms_TypeAndGetText()
+    {
+        // Navigate to Forms tab
+        var tabRef = FindRefByName(_fixture.WinFormsHandle, "Forms");
+        if (tabRef != null)
+        {
+            var clickTool = new ClickTool(_fixture.Elements);
+            await CallTool(clickTool, new { @ref = tabRef });
+            await Task.Delay(300);
+        }
+
+        var nameRef = FindRefByName(_fixture.WinFormsHandle, "Name");
+        if (nameRef == null)
+        {
+            _output.WriteLine("SKIP: Could not find Name text box");
+            return;
+        }
+
+        // Fill the name field
+        var fillTool = new FillTool(_fixture.Elements);
+        var fillResult = await CallTool(fillTool, new { @ref = nameRef, value = "Test User" });
+        _output.WriteLine($"Fill result: {fillResult}");
+
+        // Read it back
+        var textTool = new GetTextTool(_fixture.Elements);
+        var text = await CallTool(textTool, new { @ref = nameRef });
+        _output.WriteLine($"Read back: '{text}'");
+        Assert.Equal("Test User", text);
+
+        // Clear it
+        await CallTool(fillTool, new { @ref = nameRef, value = "" });
+    }
+
+    [Fact]
+    public async Task Wpf_GetText_ReadOnlyField()
+    {
+        // Navigate to Forms tab
+        var tabRef = FindRefByName(_fixture.WpfHandle, "Forms");
+        if (tabRef != null)
+        {
+            var clickTool = new ClickTool(_fixture.Elements);
+            await CallTool(clickTool, new { @ref = tabRef });
+            await Task.Delay(300);
+        }
+
+        var resultRef = FindRefByName(_fixture.WpfHandle, "Result");
+        if (resultRef == null)
+        {
+            _output.WriteLine("SKIP: Could not find Result text box");
+            return;
+        }
+
+        var tool = new GetTextTool(_fixture.Elements);
+        var text = await CallTool(tool, new { @ref = resultRef });
+        _output.WriteLine($"Result text: '{text}'");
+        Assert.Equal("Computed value here", text);
+    }
+}

--- a/tests/FlaUI.Mcp.IntegrationTests/TextAndValueTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/TextAndValueTests.cs
@@ -33,8 +33,6 @@ public class TextAndValueTests
     {
         var builder = new SnapshotBuilder(_fixture.Elements);
         var window = _fixture.Session.GetWindow(handle)!;
-        builder.BuildSnapshot(handle, window);
-        // Search snapshot lines for the name
         var snapshot = builder.BuildSnapshot(handle, window);
         foreach (var line in snapshot.Split('\n'))
         {

--- a/tests/FlaUI.Mcp.IntegrationTests/TextAndValueTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/TextAndValueTests.cs
@@ -1,6 +1,3 @@
-using System.Text.Json;
-using PlaywrightWindows.Mcp;
-using PlaywrightWindows.Mcp.Core;
 using PlaywrightWindows.Mcp.Tools;
 using Xunit.Abstractions;
 
@@ -21,45 +18,20 @@ public class TextAndValueTests
         _output = output;
     }
 
-    private async Task<string> CallTool(ToolBase tool, object args)
-    {
-        var json = JsonSerializer.Serialize(args, McpProtocol.JsonOptions);
-        var element = JsonSerializer.Deserialize<JsonElement>(json);
-        var result = await tool.ExecuteAsync(element);
-        return result.Content.FirstOrDefault()?.Text ?? "";
-    }
-
-    private string? FindRefByName(string handle, string name)
-    {
-        var builder = new SnapshotBuilder(_fixture.Elements);
-        var window = _fixture.Session.GetWindow(handle)!;
-        var snapshot = builder.BuildSnapshot(handle, window);
-        foreach (var line in snapshot.Split('\n'))
-        {
-            if (line.Contains($"\"{name}\"") && line.Contains("[ref="))
-            {
-                var refStart = line.IndexOf("[ref=") + 5;
-                var refEnd = line.IndexOf("]", refStart);
-                return line[refStart..refEnd];
-            }
-        }
-        return null;
-    }
-
     [Fact]
     public async Task WinForms_GetText_ReadOnlyField()
     {
         // Navigate to Forms tab first by finding and clicking it
-        var tabRef = FindRefByName(_fixture.WinFormsHandle, "Forms");
+        var tabRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Forms");
         if (tabRef != null)
         {
             var clickTool = new ClickTool(_fixture.Elements);
-            await CallTool(clickTool, new { @ref = tabRef });
+            await _fixture.CallTool(clickTool, new { @ref = tabRef });
             await Task.Delay(300);
         }
 
         // Re-snapshot after tab switch
-        var resultRef = FindRefByName(_fixture.WinFormsHandle, "Result");
+        var resultRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Result");
         if (resultRef == null)
         {
             _output.WriteLine("SKIP: Could not find Result text box");
@@ -67,7 +39,7 @@ public class TextAndValueTests
         }
 
         var tool = new GetTextTool(_fixture.Elements);
-        var text = await CallTool(tool, new { @ref = resultRef });
+        var text = await _fixture.CallTool(tool, new { @ref = resultRef });
         _output.WriteLine($"Result text: '{text}'");
         Assert.Equal("Computed value here", text);
     }
@@ -76,15 +48,15 @@ public class TextAndValueTests
     public async Task WinForms_TypeAndGetText()
     {
         // Navigate to Forms tab
-        var tabRef = FindRefByName(_fixture.WinFormsHandle, "Forms");
+        var tabRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Forms");
         if (tabRef != null)
         {
             var clickTool = new ClickTool(_fixture.Elements);
-            await CallTool(clickTool, new { @ref = tabRef });
+            await _fixture.CallTool(clickTool, new { @ref = tabRef });
             await Task.Delay(300);
         }
 
-        var nameRef = FindRefByName(_fixture.WinFormsHandle, "Name");
+        var nameRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Name");
         if (nameRef == null)
         {
             _output.WriteLine("SKIP: Could not find Name text box");
@@ -93,32 +65,32 @@ public class TextAndValueTests
 
         // Fill the name field
         var fillTool = new FillTool(_fixture.Elements);
-        var fillResult = await CallTool(fillTool, new { @ref = nameRef, value = "Test User" });
+        var fillResult = await _fixture.CallTool(fillTool, new { @ref = nameRef, value = "Test User" });
         _output.WriteLine($"Fill result: {fillResult}");
 
         // Read it back
         var textTool = new GetTextTool(_fixture.Elements);
-        var text = await CallTool(textTool, new { @ref = nameRef });
+        var text = await _fixture.CallTool(textTool, new { @ref = nameRef });
         _output.WriteLine($"Read back: '{text}'");
         Assert.Equal("Test User", text);
 
         // Clear it
-        await CallTool(fillTool, new { @ref = nameRef, value = "" });
+        await _fixture.CallTool(fillTool, new { @ref = nameRef, value = "" });
     }
 
     [Fact]
     public async Task Wpf_GetText_ReadOnlyField()
     {
         // Navigate to Forms tab
-        var tabRef = FindRefByName(_fixture.WpfHandle, "Forms");
+        var tabRef = _fixture.FindRefByName(_fixture.WpfHandle, "Forms");
         if (tabRef != null)
         {
             var clickTool = new ClickTool(_fixture.Elements);
-            await CallTool(clickTool, new { @ref = tabRef });
+            await _fixture.CallTool(clickTool, new { @ref = tabRef });
             await Task.Delay(300);
         }
 
-        var resultRef = FindRefByName(_fixture.WpfHandle, "Result");
+        var resultRef = _fixture.FindRefByName(_fixture.WpfHandle, "Result");
         if (resultRef == null)
         {
             _output.WriteLine("SKIP: Could not find Result text box");
@@ -126,7 +98,7 @@ public class TextAndValueTests
         }
 
         var tool = new GetTextTool(_fixture.Elements);
-        var text = await CallTool(tool, new { @ref = resultRef });
+        var text = await _fixture.CallTool(tool, new { @ref = resultRef });
         _output.WriteLine($"Result text: '{text}'");
         Assert.Equal("Computed value here", text);
     }

--- a/tests/TestApps/WinFormsTestApp/MainForm.cs
+++ b/tests/TestApps/WinFormsTestApp/MainForm.cs
@@ -264,7 +264,7 @@ namespace WinFormsTestApp
                     $"ITEM-{i + 1:D3}",
                     $"Test Item {i + 1}",
                     categories[i % categories.Length],
-                    $"{rng.Next(1, 1000):F2}"
+                    $"{rng.Next(1, 1000)}"
                 );
             }
 

--- a/tests/TestApps/WinFormsTestApp/MainForm.cs
+++ b/tests/TestApps/WinFormsTestApp/MainForm.cs
@@ -1,0 +1,495 @@
+using System;
+using System.Data;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace WinFormsTestApp
+{
+    /// <summary>
+    /// Test application for FlaUI-MCP integration tests.
+    /// Each tab exercises a different set of MCP tool capabilities.
+    /// </summary>
+    public class MainForm : Form
+    {
+        private TabControl _tabs = null!;
+
+        public MainForm()
+        {
+            Text = "FlaUI-MCP Test App";
+            Name = "MainForm";
+            Size = new Size(800, 600);
+            StartPosition = FormStartPosition.CenterScreen;
+
+            _tabs = new TabControl { Dock = DockStyle.Fill, Name = "MainTabs" };
+            Controls.Add(_tabs);
+
+            _tabs.TabPages.Add(CreateButtonsTab());
+            _tabs.TabPages.Add(CreateFormsTab());
+            _tabs.TabPages.Add(CreateGridTab());
+            _tabs.TabPages.Add(CreateTreeTab());
+            _tabs.TabPages.Add(CreateDialogTab());
+        }
+
+        /// <summary>
+        /// Tab 1: Buttons with various states and patterns.
+        /// Tests: windows_click (invoke/mouse/toggle), windows_find (by role/state),
+        ///        windows_get_value (toggle state), windows_snapshot (state indicators)
+        /// </summary>
+        private TabPage CreateButtonsTab()
+        {
+            var tab = new TabPage("Buttons") { Name = "ButtonsTab" };
+            var layout = new FlowLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                FlowDirection = FlowDirection.TopDown,
+                Padding = new Padding(10),
+                AutoScroll = true
+            };
+            tab.Controls.Add(layout);
+
+            // Simple button with click counter
+            var clickCount = 0;
+            var counterLabel = new Label
+            {
+                Text = "Click count: 0",
+                Name = "ClickCountLabel",
+                AutoSize = true
+            };
+            var clickButton = new Button
+            {
+                Text = "Click Me",
+                Name = "ClickMeButton",
+                AutoSize = true
+            };
+            clickButton.Click += (s, e) =>
+            {
+                clickCount++;
+                counterLabel.Text = $"Click count: {clickCount}";
+            };
+            layout.Controls.Add(clickButton);
+            layout.Controls.Add(counterLabel);
+
+            // Button that enables/disables based on checkbox
+            var enableCheckbox = new CheckBox
+            {
+                Text = "Enable the button below",
+                Name = "EnableCheckbox",
+                Checked = false,
+                AutoSize = true
+            };
+            var conditionalButton = new Button
+            {
+                Text = "Conditional Button",
+                Name = "ConditionalButton",
+                Enabled = false,
+                AutoSize = true
+            };
+            enableCheckbox.CheckedChanged += (s, e) =>
+            {
+                conditionalButton.Enabled = enableCheckbox.Checked;
+            };
+            layout.Controls.Add(new Label { Text = "", AutoSize = true }); // spacer
+            layout.Controls.Add(enableCheckbox);
+            layout.Controls.Add(conditionalButton);
+
+            // Radio buttons
+            var radioGroup = new GroupBox
+            {
+                Text = "Radio Group",
+                Name = "RadioGroup",
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink
+            };
+            var radioLayout = new FlowLayoutPanel
+            {
+                FlowDirection = FlowDirection.TopDown,
+                AutoSize = true,
+                Dock = DockStyle.Fill
+            };
+            radioGroup.Controls.Add(radioLayout);
+            var radio1 = new RadioButton { Text = "Option A", Name = "RadioA", Checked = true, AutoSize = true };
+            var radio2 = new RadioButton { Text = "Option B", Name = "RadioB", AutoSize = true };
+            var radio3 = new RadioButton { Text = "Option C", Name = "RadioC", AutoSize = true };
+            radioLayout.Controls.Add(radio1);
+            radioLayout.Controls.Add(radio2);
+            radioLayout.Controls.Add(radio3);
+            layout.Controls.Add(radioGroup);
+
+            return tab;
+        }
+
+        /// <summary>
+        /// Tab 2: Form controls for text input and values.
+        /// Tests: windows_type, windows_fill, windows_get_text, windows_get_value,
+        ///        windows_press_key, windows_find (by automationId)
+        /// </summary>
+        private TabPage CreateFormsTab()
+        {
+            var tab = new TabPage("Forms") { Name = "FormsTab" };
+            var layout = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 2,
+                Padding = new Padding(10),
+                AutoScroll = true
+            };
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
+            tab.Controls.Add(layout);
+
+            // Text input
+            layout.Controls.Add(new Label { Text = "Name:", AutoSize = true, Anchor = AnchorStyles.Left });
+            var nameBox = new TextBox { Name = "NameTextBox", Width = 200 };
+            nameBox.AccessibleName = "Name";
+            layout.Controls.Add(nameBox);
+
+            // Password input
+            layout.Controls.Add(new Label { Text = "Password:", AutoSize = true, Anchor = AnchorStyles.Left });
+            var passBox = new TextBox { Name = "PasswordTextBox", Width = 200, UseSystemPasswordChar = true };
+            passBox.AccessibleName = "Password";
+            layout.Controls.Add(passBox);
+
+            // Multiline text
+            layout.Controls.Add(new Label { Text = "Notes:", AutoSize = true, Anchor = AnchorStyles.Left });
+            var notesBox = new TextBox
+            {
+                Name = "NotesTextBox",
+                Multiline = true,
+                Height = 80,
+                Width = 200,
+                ScrollBars = ScrollBars.Vertical
+            };
+            notesBox.AccessibleName = "Notes";
+            layout.Controls.Add(notesBox);
+
+            // ComboBox
+            layout.Controls.Add(new Label { Text = "Status:", AutoSize = true, Anchor = AnchorStyles.Left });
+            var combo = new ComboBox { Name = "StatusComboBox", Width = 200, DropDownStyle = ComboBoxStyle.DropDownList };
+            combo.AccessibleName = "Status";
+            combo.Items.AddRange(new object[] { "Active", "Inactive", "Pending" });
+            combo.SelectedIndex = 0;
+            layout.Controls.Add(combo);
+
+            // Slider
+            layout.Controls.Add(new Label { Text = "Volume:", AutoSize = true, Anchor = AnchorStyles.Left });
+            var slider = new TrackBar
+            {
+                Name = "VolumeSlider",
+                Minimum = 0,
+                Maximum = 100,
+                Value = 50,
+                Width = 200
+            };
+            slider.AccessibleName = "Volume";
+            layout.Controls.Add(slider);
+
+            // Read-only display
+            layout.Controls.Add(new Label { Text = "Result:", AutoSize = true, Anchor = AnchorStyles.Left });
+            var resultBox = new TextBox
+            {
+                Name = "ResultTextBox",
+                Width = 200,
+                ReadOnly = true,
+                Text = "Computed value here"
+            };
+            resultBox.AccessibleName = "Result";
+            layout.Controls.Add(resultBox);
+
+            return tab;
+        }
+
+        /// <summary>
+        /// Tab 3: DataGridView with test data.
+        /// Tests: windows_table, windows_snapshot (maxTableRows), windows_find (in grids),
+        ///        windows_get_value (cell values), header detection
+        /// </summary>
+        private TabPage CreateGridTab()
+        {
+            var tab = new TabPage("Grid") { Name = "GridTab" };
+            var layout = new Panel { Dock = DockStyle.Fill, Padding = new Padding(10) };
+            tab.Controls.Add(layout);
+
+            var grid = new DataGridView
+            {
+                Name = "TestDataGrid",
+                Dock = DockStyle.Fill,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill,
+                AllowUserToAddRows = false,
+                ReadOnly = false,
+                SelectionMode = DataGridViewSelectionMode.FullRowSelect
+            };
+            grid.AccessibleName = "Test Data";
+
+            // Add columns
+            var selectCol = new DataGridViewCheckBoxColumn
+            {
+                Name = "Select",
+                HeaderText = "Select",
+                Width = 50
+            };
+            grid.Columns.Add(selectCol);
+
+            grid.Columns.Add(new DataGridViewTextBoxColumn
+            {
+                Name = "ID",
+                HeaderText = "ID",
+                ReadOnly = true
+            });
+            grid.Columns.Add(new DataGridViewTextBoxColumn
+            {
+                Name = "Name",
+                HeaderText = "Name",
+                ReadOnly = true
+            });
+            grid.Columns.Add(new DataGridViewTextBoxColumn
+            {
+                Name = "Category",
+                HeaderText = "Category",
+                ReadOnly = true
+            });
+            grid.Columns.Add(new DataGridViewTextBoxColumn
+            {
+                Name = "Value",
+                HeaderText = "Value",
+                ReadOnly = true
+            });
+
+            // Add test data - enough rows to test limiting
+            var categories = new[] { "Alpha", "Beta", "Gamma", "Delta" };
+            var rng = new Random(42); // deterministic seed
+            for (int i = 0; i < 50; i++)
+            {
+                grid.Rows.Add(
+                    false,
+                    $"ITEM-{i + 1:D3}",
+                    $"Test Item {i + 1}",
+                    categories[i % categories.Length],
+                    $"{rng.Next(1, 1000):F2}"
+                );
+            }
+
+            // Status bar showing selection count
+            var statusPanel = new Panel { Dock = DockStyle.Bottom, Height = 35 };
+            var selectionLabel = new Label
+            {
+                Text = "0 items selected",
+                Name = "SelectionCountLabel",
+                AutoSize = true,
+                Location = new Point(10, 8)
+            };
+            var selectAllButton = new Button
+            {
+                Text = "Select All",
+                Name = "SelectAllButton",
+                Location = new Point(200, 5),
+                Enabled = true
+            };
+            var clearButton = new Button
+            {
+                Text = "Clear Selection",
+                Name = "ClearSelectionButton",
+                Location = new Point(300, 5),
+                Enabled = false
+            };
+
+            grid.CellValueChanged += (s, e) =>
+            {
+                if (e.ColumnIndex == 0) // Select column
+                {
+                    var count = 0;
+                    foreach (DataGridViewRow row in grid.Rows)
+                    {
+                        if (row.Cells[0].Value is true) count++;
+                    }
+                    selectionLabel.Text = $"{count} items selected";
+                    clearButton.Enabled = count > 0;
+                }
+            };
+            grid.CurrentCellDirtyStateChanged += (s, e) =>
+            {
+                if (grid.IsCurrentCellDirty)
+                    grid.CommitEdit(DataGridViewDataErrorContexts.Commit);
+            };
+
+            selectAllButton.Click += (s, e) =>
+            {
+                foreach (DataGridViewRow row in grid.Rows)
+                    row.Cells[0].Value = true;
+            };
+            clearButton.Click += (s, e) =>
+            {
+                foreach (DataGridViewRow row in grid.Rows)
+                    row.Cells[0].Value = false;
+            };
+
+            statusPanel.Controls.Add(selectionLabel);
+            statusPanel.Controls.Add(selectAllButton);
+            statusPanel.Controls.Add(clearButton);
+            layout.Controls.Add(grid);
+            layout.Controls.Add(statusPanel);
+
+            return tab;
+        }
+
+        /// <summary>
+        /// Tab 4: TreeView and ListView.
+        /// Tests: windows_snapshot (tree depth), windows_click (expand/collapse),
+        ///        windows_find (treeitem role), windows_get_text
+        /// </summary>
+        private TabPage CreateTreeTab()
+        {
+            var tab = new TabPage("Trees") { Name = "TreesTab" };
+            var split = new SplitContainer
+            {
+                Dock = DockStyle.Fill,
+                Orientation = Orientation.Vertical,
+                SplitterDistance = 300
+            };
+            tab.Controls.Add(split);
+
+            // TreeView
+            var tree = new TreeView
+            {
+                Name = "TestTreeView",
+                Dock = DockStyle.Fill
+            };
+            tree.AccessibleName = "Category Tree";
+            var root1 = tree.Nodes.Add("Fruits");
+            root1.Nodes.Add("Apple");
+            root1.Nodes.Add("Banana");
+            root1.Nodes.Add("Cherry");
+            var root2 = tree.Nodes.Add("Vegetables");
+            root2.Nodes.Add("Carrot");
+            root2.Nodes.Add("Broccoli");
+            var root3 = tree.Nodes.Add("Grains");
+            root3.Nodes.Add("Rice");
+            root3.Nodes.Add("Wheat");
+            root3.Nodes.Add("Oats");
+            tree.ExpandAll();
+            split.Panel1.Controls.Add(tree);
+
+            // ListView
+            var list = new ListView
+            {
+                Name = "TestListView",
+                Dock = DockStyle.Fill,
+                View = View.Details,
+                FullRowSelect = true
+            };
+            list.AccessibleName = "Item List";
+            list.Columns.Add("Name", 150);
+            list.Columns.Add("Type", 100);
+            list.Columns.Add("Size", 80);
+            list.Items.Add(new ListViewItem(new[] { "Document.pdf", "PDF", "2.4 MB" }));
+            list.Items.Add(new ListViewItem(new[] { "Photo.jpg", "Image", "4.1 MB" }));
+            list.Items.Add(new ListViewItem(new[] { "Data.csv", "CSV", "156 KB" }));
+            list.Items.Add(new ListViewItem(new[] { "Report.docx", "Word", "890 KB" }));
+            split.Panel2.Controls.Add(list);
+
+            return tab;
+        }
+
+        /// <summary>
+        /// Tab 5: Dialog launchers for testing window management.
+        /// Tests: windows_wait (exists/gone), windows_launch, windows_close,
+        ///        windows_list_windows, windows_focus
+        /// </summary>
+        private TabPage CreateDialogTab()
+        {
+            var tab = new TabPage("Dialogs") { Name = "DialogsTab" };
+            var layout = new FlowLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                FlowDirection = FlowDirection.TopDown,
+                Padding = new Padding(10)
+            };
+            tab.Controls.Add(layout);
+
+            // Button that opens a modal dialog
+            var modalButton = new Button
+            {
+                Text = "Open Modal Dialog",
+                Name = "OpenModalButton",
+                AutoSize = true
+            };
+            modalButton.Click += (s, e) =>
+            {
+                using var dialog = new Form
+                {
+                    Text = "Test Modal Dialog",
+                    Name = "TestModalDialog",
+                    Size = new Size(300, 200),
+                    StartPosition = FormStartPosition.CenterParent,
+                    FormBorderStyle = FormBorderStyle.FixedDialog,
+                    MaximizeBox = false,
+                    MinimizeBox = false
+                };
+                var okButton = new Button
+                {
+                    Text = "OK",
+                    Name = "OKButton",
+                    DialogResult = DialogResult.OK,
+                    Location = new Point(100, 120)
+                };
+                dialog.Controls.Add(okButton);
+                dialog.Controls.Add(new Label
+                {
+                    Text = "This is a test modal dialog.",
+                    Name = "DialogLabel",
+                    Location = new Point(20, 30),
+                    AutoSize = true
+                });
+                dialog.AcceptButton = okButton;
+                dialog.ShowDialog(this);
+            };
+            layout.Controls.Add(modalButton);
+
+            // Button that opens a modeless dialog
+            var modelessButton = new Button
+            {
+                Text = "Open Modeless Dialog",
+                Name = "OpenModelessButton",
+                AutoSize = true
+            };
+            modelessButton.Click += (s, e) =>
+            {
+                var dialog = new Form
+                {
+                    Text = "Test Modeless Dialog",
+                    Name = "TestModelessDialog",
+                    Size = new Size(300, 200),
+                    StartPosition = FormStartPosition.CenterParent
+                };
+                var closeButton = new Button
+                {
+                    Text = "Close",
+                    Name = "CloseDialogButton",
+                    Location = new Point(100, 120)
+                };
+                closeButton.Click += (s2, e2) => dialog.Close();
+                dialog.Controls.Add(closeButton);
+                dialog.Controls.Add(new Label
+                {
+                    Text = "This is a modeless dialog.\nClose it to test wait-gone.",
+                    Name = "ModelessDialogLabel",
+                    Location = new Point(20, 30),
+                    AutoSize = true
+                });
+                dialog.Show(this);
+            };
+            layout.Controls.Add(modelessButton);
+
+            // Status text that updates
+            var statusLabel = new Label
+            {
+                Text = "Ready",
+                Name = "DialogStatusLabel",
+                AutoSize = true
+            };
+            layout.Controls.Add(new Label { Text = "", AutoSize = true }); // spacer
+            layout.Controls.Add(statusLabel);
+
+            return tab;
+        }
+    }
+}

--- a/tests/TestApps/WinFormsTestApp/Program.cs
+++ b/tests/TestApps/WinFormsTestApp/Program.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Windows.Forms;
+
+namespace WinFormsTestApp
+{
+    static class Program
+    {
+        [STAThread]
+        static void Main()
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            Application.Run(new MainForm());
+        }
+    }
+}

--- a/tests/TestApps/WinFormsTestApp/WinFormsTestApp.csproj
+++ b/tests/TestApps/WinFormsTestApp/WinFormsTestApp.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net481</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <AssemblyName>WinFormsTestApp</AssemblyName>
+    <RootNamespace>WinFormsTestApp</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/tests/TestApps/WpfTestApp/App.xaml
+++ b/tests/TestApps/WpfTestApp/App.xaml
@@ -1,0 +1,5 @@
+<Application x:Class="WpfTestApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+</Application>

--- a/tests/TestApps/WpfTestApp/App.xaml.cs
+++ b/tests/TestApps/WpfTestApp/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace WpfTestApp
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/tests/TestApps/WpfTestApp/MainWindow.xaml
+++ b/tests/TestApps/WpfTestApp/MainWindow.xaml
@@ -1,0 +1,167 @@
+<Window x:Class="WpfTestApp.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="FlaUI-MCP WPF Test App"
+        Width="800" Height="600"
+        WindowStartupLocation="CenterScreen"
+        x:Name="MainWindow1">
+    <TabControl x:Name="MainTabs" AutomationProperties.Name="Main Tabs">
+
+        <!-- Tab 1: Buttons and state changes -->
+        <TabItem Header="Buttons" x:Name="ButtonsTab" AutomationProperties.AutomationId="ButtonsTab">
+            <StackPanel Margin="10" Orientation="Vertical">
+                <Button Content="Click Me" x:Name="ClickMeButton" Click="ClickMe_Click"
+                        AutomationProperties.AutomationId="ClickMeButton" Margin="0,0,0,5"
+                        HorizontalAlignment="Left" Padding="10,5"/>
+                <TextBlock x:Name="ClickCountLabel" Text="Click count: 0"
+                           AutomationProperties.AutomationId="ClickCountLabel" Margin="0,0,0,15"/>
+
+                <CheckBox Content="Enable the button below" x:Name="EnableCheckbox"
+                          AutomationProperties.AutomationId="EnableCheckbox"
+                          Checked="EnableCheckbox_Changed" Unchecked="EnableCheckbox_Changed"
+                          Margin="0,0,0,5"/>
+                <Button Content="Conditional Button" x:Name="ConditionalButton" IsEnabled="False"
+                        AutomationProperties.AutomationId="ConditionalButton"
+                        HorizontalAlignment="Left" Padding="10,5" Margin="0,0,0,15"/>
+
+                <GroupBox Header="Radio Group" x:Name="RadioGroup" Margin="0,0,0,10"
+                          AutomationProperties.AutomationId="RadioGroup">
+                    <StackPanel Margin="5">
+                        <RadioButton Content="Option A" x:Name="RadioA" IsChecked="True"
+                                     AutomationProperties.AutomationId="RadioA"/>
+                        <RadioButton Content="Option B" x:Name="RadioB"
+                                     AutomationProperties.AutomationId="RadioB"/>
+                        <RadioButton Content="Option C" x:Name="RadioC"
+                                     AutomationProperties.AutomationId="RadioC"/>
+                    </StackPanel>
+                </GroupBox>
+            </StackPanel>
+        </TabItem>
+
+        <!-- Tab 2: Form inputs -->
+        <TabItem Header="Forms" x:Name="FormsTab" AutomationProperties.AutomationId="FormsTab">
+            <Grid Margin="10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <Label Content="Name:" Grid.Row="0" VerticalAlignment="Center"/>
+                <TextBox x:Name="NameTextBox" Grid.Row="0" Grid.Column="1" Margin="5"
+                         AutomationProperties.Name="Name"
+                         AutomationProperties.AutomationId="NameTextBox"/>
+
+                <Label Content="Email:" Grid.Row="1" VerticalAlignment="Center"/>
+                <TextBox x:Name="EmailTextBox" Grid.Row="1" Grid.Column="1" Margin="5"
+                         AutomationProperties.Name="Email"
+                         AutomationProperties.AutomationId="EmailTextBox"/>
+
+                <Label Content="Status:" Grid.Row="2" VerticalAlignment="Center"/>
+                <ComboBox x:Name="StatusComboBox" Grid.Row="2" Grid.Column="1" Margin="5"
+                          AutomationProperties.Name="Status"
+                          AutomationProperties.AutomationId="StatusComboBox"
+                          SelectedIndex="0">
+                    <ComboBoxItem Content="Active"/>
+                    <ComboBoxItem Content="Inactive"/>
+                    <ComboBoxItem Content="Pending"/>
+                </ComboBox>
+
+                <Label Content="Priority:" Grid.Row="3" VerticalAlignment="Center"/>
+                <Slider x:Name="PrioritySlider" Grid.Row="3" Grid.Column="1" Margin="5"
+                        Minimum="0" Maximum="10" Value="5" TickFrequency="1" IsSnapToTickEnabled="True"
+                        AutomationProperties.Name="Priority"
+                        AutomationProperties.AutomationId="PrioritySlider"/>
+
+                <Label Content="Notes:" Grid.Row="4" VerticalAlignment="Top"/>
+                <TextBox x:Name="NotesTextBox" Grid.Row="4" Grid.Column="1" Margin="5"
+                         Height="80" TextWrapping="Wrap" AcceptsReturn="True"
+                         VerticalScrollBarVisibility="Auto"
+                         AutomationProperties.Name="Notes"
+                         AutomationProperties.AutomationId="NotesTextBox"/>
+
+                <Label Content="Result:" Grid.Row="5" VerticalAlignment="Center"/>
+                <TextBox x:Name="ResultTextBox" Grid.Row="5" Grid.Column="1" Margin="5"
+                         IsReadOnly="True" Text="Computed value here"
+                         AutomationProperties.Name="Result"
+                         AutomationProperties.AutomationId="ResultTextBox"/>
+            </Grid>
+        </TabItem>
+
+        <!-- Tab 3: DataGrid -->
+        <TabItem Header="Grid" x:Name="GridTab" AutomationProperties.AutomationId="GridTab">
+            <DockPanel Margin="10">
+                <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="0,5,0,0">
+                    <TextBlock x:Name="GridSelectionLabel" Text="0 items selected"
+                               AutomationProperties.AutomationId="GridSelectionLabel"
+                               VerticalAlignment="Center" Margin="0,0,10,0"/>
+                    <Button Content="Select All" x:Name="GridSelectAllButton"
+                            AutomationProperties.AutomationId="GridSelectAllButton"
+                            Click="GridSelectAll_Click" Margin="0,0,5,0" Padding="10,3"/>
+                    <Button Content="Clear Selection" x:Name="GridClearButton" IsEnabled="False"
+                            AutomationProperties.AutomationId="GridClearButton"
+                            Click="GridClear_Click" Padding="10,3"/>
+                </StackPanel>
+                <DataGrid x:Name="TestDataGrid" AutoGenerateColumns="False"
+                          AutomationProperties.Name="Test Data"
+                          AutomationProperties.AutomationId="TestDataGrid"
+                          CanUserAddRows="False" SelectionMode="Single"
+                          IsReadOnly="False">
+                    <DataGrid.Columns>
+                        <DataGridCheckBoxColumn Header="Select" Binding="{Binding Selected}" Width="60"/>
+                        <DataGridTextColumn Header="ID" Binding="{Binding ID}" IsReadOnly="True" Width="100"/>
+                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" IsReadOnly="True" Width="*"/>
+                        <DataGridTextColumn Header="Category" Binding="{Binding Category}" IsReadOnly="True" Width="120"/>
+                        <DataGridTextColumn Header="Value" Binding="{Binding Value}" IsReadOnly="True" Width="100"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </DockPanel>
+        </TabItem>
+
+        <!-- Tab 4: TreeView -->
+        <TabItem Header="Trees" x:Name="TreesTab" AutomationProperties.AutomationId="TreesTab">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <TreeView x:Name="TestTreeView" Margin="10"
+                          AutomationProperties.Name="Category Tree"
+                          AutomationProperties.AutomationId="TestTreeView">
+                    <TreeViewItem Header="Fruits" IsExpanded="True">
+                        <TreeViewItem Header="Apple"/>
+                        <TreeViewItem Header="Banana"/>
+                        <TreeViewItem Header="Cherry"/>
+                    </TreeViewItem>
+                    <TreeViewItem Header="Vegetables" IsExpanded="True">
+                        <TreeViewItem Header="Carrot"/>
+                        <TreeViewItem Header="Broccoli"/>
+                    </TreeViewItem>
+                    <TreeViewItem Header="Grains" IsExpanded="True">
+                        <TreeViewItem Header="Rice"/>
+                        <TreeViewItem Header="Wheat"/>
+                        <TreeViewItem Header="Oats"/>
+                    </TreeViewItem>
+                </TreeView>
+                <ListView x:Name="TestListView" Grid.Column="1" Margin="10"
+                          AutomationProperties.Name="Item List"
+                          AutomationProperties.AutomationId="TestListView">
+                    <ListView.View>
+                        <GridView>
+                            <GridViewColumn Header="Name" Width="150" DisplayMemberBinding="{Binding Name}"/>
+                            <GridViewColumn Header="Type" Width="100" DisplayMemberBinding="{Binding Type}"/>
+                            <GridViewColumn Header="Size" Width="80" DisplayMemberBinding="{Binding Size}"/>
+                        </GridView>
+                    </ListView.View>
+                </ListView>
+            </Grid>
+        </TabItem>
+    </TabControl>
+</Window>

--- a/tests/TestApps/WpfTestApp/MainWindow.xaml.cs
+++ b/tests/TestApps/WpfTestApp/MainWindow.xaml.cs
@@ -1,0 +1,105 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows;
+
+namespace WpfTestApp
+{
+    public partial class MainWindow : Window
+    {
+        private int _clickCount;
+        private ObservableCollection<GridItem> _gridItems = new();
+
+        public MainWindow()
+        {
+            InitializeComponent();
+            LoadGridData();
+            LoadListData();
+        }
+
+        // Buttons tab
+        private void ClickMe_Click(object sender, RoutedEventArgs e)
+        {
+            _clickCount++;
+            ClickCountLabel.Text = $"Click count: {_clickCount}";
+        }
+
+        private void EnableCheckbox_Changed(object sender, RoutedEventArgs e)
+        {
+            ConditionalButton.IsEnabled = EnableCheckbox.IsChecked == true;
+        }
+
+        // Grid tab
+        private void LoadGridData()
+        {
+            var categories = new[] { "Alpha", "Beta", "Gamma", "Delta" };
+            var rng = new System.Random(42);
+            for (int i = 0; i < 50; i++)
+            {
+                _gridItems.Add(new GridItem
+                {
+                    Selected = false,
+                    ID = $"ITEM-{i + 1:D3}",
+                    Name = $"Test Item {i + 1}",
+                    Category = categories[i % categories.Length],
+                    Value = $"{rng.Next(1, 1000)}"
+                });
+            }
+            TestDataGrid.ItemsSource = _gridItems;
+        }
+
+        private void GridSelectAll_Click(object sender, RoutedEventArgs e)
+        {
+            foreach (var item in _gridItems) item.Selected = true;
+            TestDataGrid.Items.Refresh();
+            UpdateGridSelection();
+        }
+
+        private void GridClear_Click(object sender, RoutedEventArgs e)
+        {
+            foreach (var item in _gridItems) item.Selected = false;
+            TestDataGrid.Items.Refresh();
+            UpdateGridSelection();
+        }
+
+        private void UpdateGridSelection()
+        {
+            var count = 0;
+            foreach (var item in _gridItems)
+                if (item.Selected) count++;
+            GridSelectionLabel.Text = $"{count} items selected";
+            GridClearButton.IsEnabled = count > 0;
+        }
+
+        // Trees tab
+        private void LoadListData()
+        {
+            TestListView.Items.Add(new FileItem { Name = "Document.pdf", Type = "PDF", Size = "2.4 MB" });
+            TestListView.Items.Add(new FileItem { Name = "Photo.jpg", Type = "Image", Size = "4.1 MB" });
+            TestListView.Items.Add(new FileItem { Name = "Data.csv", Type = "CSV", Size = "156 KB" });
+            TestListView.Items.Add(new FileItem { Name = "Report.docx", Type = "Word", Size = "890 KB" });
+        }
+    }
+
+    public class GridItem : INotifyPropertyChanged
+    {
+        private bool _selected;
+        public bool Selected
+        {
+            get => _selected;
+            set { _selected = value; PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Selected))); }
+        }
+        public string ID { get; set; } = "";
+        public string Name { get; set; } = "";
+        public string Category { get; set; } = "";
+        public string Value { get; set; } = "";
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+    }
+
+    public class FileItem
+    {
+        public string Name { get; set; } = "";
+        public string Type { get; set; } = "";
+        public string Size { get; set; } = "";
+    }
+}

--- a/tests/TestApps/WpfTestApp/WpfTestApp.csproj
+++ b/tests/TestApps/WpfTestApp/WpfTestApp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <AssemblyName>WpfTestApp</AssemblyName>
+    <RootNamespace>WpfTestApp</RootNamespace>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- Adds purpose-built WinForms (.NET Framework 4.8.1) and WPF (.NET 8) test applications for exercising MCP tool code paths
- Adds xunit integration test project with 13 tests covering snapshot, click, and text tools against both frameworks
- Test fixture launches apps once per collection for stable window handles throughout the test run

### Test apps

Each app has a tabbed interface with controls designed to exercise specific MCP features:

| Tab | Controls | Tests |
|-----|----------|-------|
| Buttons | Click counter, enable/disable checkbox+button, radio group | click, snapshot state indicators, find by role |
| Forms | TextBox, ComboBox, TrackBar, read-only field | type, fill, get_text, get_value |
| Grid | 50-row DataGridView with checkbox column and selection controls | table, snapshot row limiting, header detection |
| Trees | TreeView, ListView | snapshot depth, find by role |
| Dialogs (WinForms only) | Modal and modeless dialog launchers | wait exists/gone, close, focus |

### Running tests

```powershell
# Build test apps first
dotnet build tests/TestApps/WinFormsTestApp
dotnet build tests/TestApps/WpfTestApp

# Run integration tests
dotnet test tests/FlaUI.Mcp.IntegrationTests
```

Note: Tests require a Windows desktop (they launch GUI applications).

## Test plan

- [x] WinFormsTestApp builds and launches (net481)
- [x] WpfTestApp builds and launches (net8.0-windows)
- [x] All 13 integration tests pass
- [x] Tests verify both WinForms and WPF code paths
- [x] Enabled state change detection works (checkbox toggle → button state update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)