### PR TITLE
Add windows_press_key tool for keyboard input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - WpfTestApp: equivalent WPF controls for cross-framework validation
   - 13 integration tests covering snapshot, click, and text tools
   - Shared test fixture for stable window handles across test runs
+- `windows_press_key` tool for sending keyboard input (individual keys and modifier combinations)
 
 ## [0.1.0] - 2024-02-02
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Or using `dotnet run`:
 | `windows_focus` | Bring a window to foreground |
 | `windows_close` | Close a window |
 | `windows_batch` | Execute multiple actions in one call |
+| `windows_press_key` | Send keyboard input (keys and combinations) |
 
 ## How It Works
 

--- a/src/FlaUI.Mcp/Program.cs
+++ b/src/FlaUI.Mcp/Program.cs
@@ -18,6 +18,7 @@ toolRegistry.RegisterTool(new ScreenshotTool(sessionManager, elementRegistry));
 toolRegistry.RegisterTool(new ListWindowsTool(sessionManager));
 toolRegistry.RegisterTool(new FocusWindowTool(sessionManager));
 toolRegistry.RegisterTool(new CloseWindowTool(sessionManager));
+toolRegistry.RegisterTool(new PressKeyTool(elementRegistry));
 toolRegistry.RegisterTool(new BatchTool(sessionManager, elementRegistry));
 
 // Create and run MCP server

--- a/src/FlaUI.Mcp/Tools/PressKeyTool.cs
+++ b/src/FlaUI.Mcp/Tools/PressKeyTool.cs
@@ -1,0 +1,186 @@
+using System.Text.Json;
+using FlaUI.Core.Input;
+using FlaUI.Core.WindowsAPI;
+using PlaywrightWindows.Mcp.Core;
+
+namespace PlaywrightWindows.Mcp.Tools;
+
+/// <summary>
+/// Press a key or key combination. Sends keyboard input to the focused element.
+/// </summary>
+public class PressKeyTool : ToolBase
+{
+    private readonly ElementRegistry _elementRegistry;
+
+    public PressKeyTool(ElementRegistry elementRegistry)
+    {
+        _elementRegistry = elementRegistry;
+    }
+
+    public override string Name => "windows_press_key";
+
+    public override string Description =>
+        "Press a key or key combination. Sends keyboard input to the currently focused element. " +
+        "Use this for individual key presses (Enter, Escape, arrow keys, single characters as key events) " +
+        "rather than text input. Use windows_type for typing text strings.";
+
+    public override object InputSchema => new
+    {
+        type = "object",
+        properties = new
+        {
+            key = new
+            {
+                type = "string",
+                description = "Key to press: 'a'-'z', '0'-'9', 'enter', 'escape', 'tab', 'space', " +
+                              "'backspace', 'delete', 'up', 'down', 'left', 'right', 'home', 'end', " +
+                              "'pageup', 'pagedown', 'f1'-'f12', or symbols like '+', '-', '=', etc."
+            },
+            modifiers = new
+            {
+                type = "array",
+                items = new { type = "string", @enum = new[] { "ctrl", "shift", "alt" } },
+                description = "Modifier keys to hold while pressing the key (e.g., [\"ctrl\", \"shift\"])"
+            },
+            @ref = new
+            {
+                type = "string",
+                description = "Element ref to focus before pressing the key. If omitted, sends to the currently focused element."
+            }
+        },
+        required = new[] { "key" }
+    };
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var keyName = GetStringArgument(arguments, "key");
+        if (string.IsNullOrEmpty(keyName))
+        {
+            return Task.FromResult(ErrorResult("Missing required argument: key"));
+        }
+
+        var modifiers = GetArgument<string[]>(arguments, "modifiers") ?? Array.Empty<string>();
+        var refId = GetStringArgument(arguments, "ref");
+
+        try
+        {
+            // Focus element if ref provided
+            if (!string.IsNullOrEmpty(refId))
+            {
+                var element = _elementRegistry.GetElement(refId);
+                if (element == null)
+                {
+                    return Task.FromResult(ErrorResult($"Element not found: {refId}. Run windows_snapshot to refresh element refs."));
+                }
+
+                element.Focus();
+                Thread.Sleep(50);
+            }
+
+            var vk = MapKeyName(keyName);
+            if (vk == null)
+            {
+                return Task.FromResult(ErrorResult($"Unknown key: '{keyName}'"));
+            }
+
+            // Build modifier list
+            var modifierKeys = new List<VirtualKeyShort>();
+            foreach (var mod in modifiers)
+            {
+                var modKey = mod.ToLowerInvariant() switch
+                {
+                    "ctrl" or "control" => VirtualKeyShort.CONTROL,
+                    "shift" => VirtualKeyShort.SHIFT,
+                    "alt" => VirtualKeyShort.ALT,
+                    _ => (VirtualKeyShort?)null
+                };
+                if (modKey == null)
+                {
+                    return Task.FromResult(ErrorResult($"Unknown modifier: '{mod}'. Use 'ctrl', 'shift', or 'alt'."));
+                }
+                modifierKeys.Add(modKey.Value);
+            }
+
+            // Press the key with modifiers
+            if (modifierKeys.Count > 0)
+            {
+                var allKeys = modifierKeys.Append(vk.Value).ToArray();
+                Keyboard.TypeSimultaneously(allKeys);
+            }
+            else
+            {
+                Keyboard.Press(vk.Value);
+            }
+
+            // Build description
+            var desc = string.Join("+", modifiers.Select(m => m.ToUpperInvariant()).Append(keyName));
+            var target = string.IsNullOrEmpty(refId) ? "" : $" (focused {refId})";
+            return Task.FromResult(TextResult($"Pressed {desc}{target}"));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ErrorResult($"Failed to press key: {ex.Message}"));
+        }
+    }
+
+    private static VirtualKeyShort? MapKeyName(string keyName)
+    {
+        // Single character keys
+        if (keyName.Length == 1)
+        {
+            var ch = keyName[0];
+            return ch switch
+            {
+                >= 'a' and <= 'z' => (VirtualKeyShort)((int)VirtualKeyShort.KEY_A + (ch - 'a')),
+                >= 'A' and <= 'Z' => (VirtualKeyShort)((int)VirtualKeyShort.KEY_A + (ch - 'A')),
+                >= '0' and <= '9' => (VirtualKeyShort)((int)VirtualKeyShort.KEY_0 + (ch - '0')),
+                ' ' => VirtualKeyShort.SPACE,
+                '+' or '=' => VirtualKeyShort.OEM_PLUS,
+                '-' => VirtualKeyShort.OEM_MINUS,
+                '.' => VirtualKeyShort.OEM_PERIOD,
+                ',' => VirtualKeyShort.OEM_COMMA,
+                '/' => VirtualKeyShort.OEM_2,
+                ';' => VirtualKeyShort.OEM_1,
+                '\'' => VirtualKeyShort.OEM_7,
+                '[' => VirtualKeyShort.OEM_4,
+                ']' => VirtualKeyShort.OEM_6,
+                '\\' => VirtualKeyShort.OEM_5,
+                '`' => VirtualKeyShort.OEM_3,
+                _ => null
+            };
+        }
+
+        // Named keys
+        return keyName.ToLowerInvariant() switch
+        {
+            "enter" or "return" => VirtualKeyShort.ENTER,
+            "escape" or "esc" => VirtualKeyShort.ESCAPE,
+            "tab" => VirtualKeyShort.TAB,
+            "space" => VirtualKeyShort.SPACE,
+            "backspace" or "back" => VirtualKeyShort.BACK,
+            "delete" or "del" => VirtualKeyShort.DELETE,
+            "up" => VirtualKeyShort.UP,
+            "down" => VirtualKeyShort.DOWN,
+            "left" => VirtualKeyShort.LEFT,
+            "right" => VirtualKeyShort.RIGHT,
+            "home" => VirtualKeyShort.HOME,
+            "end" => VirtualKeyShort.END,
+            "pageup" => VirtualKeyShort.PRIOR,
+            "pagedown" => VirtualKeyShort.NEXT,
+            "insert" => VirtualKeyShort.INSERT,
+            "f1" => VirtualKeyShort.F1,
+            "f2" => VirtualKeyShort.F2,
+            "f3" => VirtualKeyShort.F3,
+            "f4" => VirtualKeyShort.F4,
+            "f5" => VirtualKeyShort.F5,
+            "f6" => VirtualKeyShort.F6,
+            "f7" => VirtualKeyShort.F7,
+            "f8" => VirtualKeyShort.F8,
+            "f9" => VirtualKeyShort.F9,
+            "f10" => VirtualKeyShort.F10,
+            "f11" => VirtualKeyShort.F11,
+            "f12" => VirtualKeyShort.F12,
+            _ => null
+        };
+    }
+}

--- a/src/FlaUI.Mcp/Tools/PressKeyTool.cs
+++ b/src/FlaUI.Mcp/Tools/PressKeyTool.cs
@@ -51,12 +51,12 @@ public class PressKeyTool : ToolBase
         required = new[] { "key" }
     };
 
-    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    public override async Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
     {
         var keyName = GetStringArgument(arguments, "key");
         if (string.IsNullOrEmpty(keyName))
         {
-            return Task.FromResult(ErrorResult("Missing required argument: key"));
+            return ErrorResult("Missing required argument: key");
         }
 
         var modifiers = GetArgument<string[]>(arguments, "modifiers") ?? Array.Empty<string>();
@@ -70,17 +70,17 @@ public class PressKeyTool : ToolBase
                 var element = _elementRegistry.GetElement(refId);
                 if (element == null)
                 {
-                    return Task.FromResult(ErrorResult($"Element not found: {refId}. Run windows_snapshot to refresh element refs."));
+                    return ErrorResult($"Element not found: {refId}. Run windows_snapshot to refresh element refs.");
                 }
 
                 element.Focus();
-                Thread.Sleep(50);
+                await Task.Delay(50);
             }
 
             var vk = MapKeyName(keyName);
             if (vk == null)
             {
-                return Task.FromResult(ErrorResult($"Unknown key: '{keyName}'"));
+                return ErrorResult($"Unknown key: '{keyName}'");
             }
 
             // Build modifier list
@@ -96,7 +96,7 @@ public class PressKeyTool : ToolBase
                 };
                 if (modKey == null)
                 {
-                    return Task.FromResult(ErrorResult($"Unknown modifier: '{mod}'. Use 'ctrl', 'shift', or 'alt'."));
+                    return ErrorResult($"Unknown modifier: '{mod}'. Use 'ctrl', 'shift', or 'alt'.");
                 }
                 modifierKeys.Add(modKey.Value);
             }
@@ -115,11 +115,11 @@ public class PressKeyTool : ToolBase
             // Build description
             var desc = string.Join("+", modifiers.Select(m => m.ToUpperInvariant()).Append(keyName));
             var target = string.IsNullOrEmpty(refId) ? "" : $" (focused {refId})";
-            return Task.FromResult(TextResult($"Pressed {desc}{target}"));
+            return TextResult($"Pressed {desc}{target}");
         }
         catch (Exception ex)
         {
-            return Task.FromResult(ErrorResult($"Failed to press key: {ex.Message}"));
+            return ErrorResult($"Failed to press key: {ex.Message}");
         }
     }
 

--- a/src/FlaUI.Mcp/Tools/PressKeyTool.cs
+++ b/src/FlaUI.Mcp/Tools/PressKeyTool.cs
@@ -39,7 +39,7 @@ public class PressKeyTool : ToolBase
             modifiers = new
             {
                 type = "array",
-                items = new { type = "string", @enum = new[] { "ctrl", "shift", "alt" } },
+                items = new { type = "string", @enum = new[] { "ctrl", "shift", "alt", "win" } },
                 description = "Modifier keys to hold while pressing the key (e.g., [\"ctrl\", \"shift\"])"
             },
             @ref = new
@@ -92,24 +92,28 @@ public class PressKeyTool : ToolBase
                     "ctrl" or "control" => VirtualKeyShort.CONTROL,
                     "shift" => VirtualKeyShort.SHIFT,
                     "alt" => VirtualKeyShort.ALT,
+                    "win" or "windows" or "meta" or "super" => VirtualKeyShort.LWIN,
                     _ => (VirtualKeyShort?)null
                 };
                 if (modKey == null)
                 {
-                    return ErrorResult($"Unknown modifier: '{mod}'. Use 'ctrl', 'shift', or 'alt'.");
+                    return ErrorResult($"Unknown modifier: '{mod}'. Use 'ctrl', 'shift', 'alt', or 'win'.");
                 }
                 modifierKeys.Add(modKey.Value);
             }
 
-            // Press the key with modifiers
+            // Send the key with proper press+release
             if (modifierKeys.Count > 0)
             {
+                // TypeSimultaneously holds modifiers, presses key, releases all
                 var allKeys = modifierKeys.Append(vk.Value).ToArray();
                 Keyboard.TypeSimultaneously(allKeys);
             }
             else
             {
+                // Press + Release ensures the key isn't left in a stuck state
                 Keyboard.Press(vk.Value);
+                Keyboard.Release(vk.Value);
             }
 
             // Build description

--- a/tests/FlaUI.Mcp.IntegrationTests/PressKeyTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/PressKeyTests.cs
@@ -1,0 +1,131 @@
+using PlaywrightWindows.Mcp.Tools;
+using Xunit.Abstractions;
+
+namespace FlaUI.Mcp.IntegrationTests;
+
+/// <summary>
+/// Tests for windows_press_key tool using the test apps.
+/// </summary>
+[Collection("TestApps")]
+public class PressKeyTests
+{
+    private readonly TestAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public PressKeyTests(TestAppFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    [Fact]
+    public async Task PressKey_SingleKey()
+    {
+        var tool = new PressKeyTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { key = "Tab" });
+        _output.WriteLine($"Result: {result}");
+        Assert.Contains("Pressed", result);
+        Assert.Contains("Tab", result);
+    }
+
+    [Fact]
+    public async Task PressKey_WithModifier()
+    {
+        var tool = new PressKeyTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { key = "a", modifiers = new[] { "ctrl" } });
+        _output.WriteLine($"Result: {result}");
+        Assert.Contains("Pressed", result);
+        Assert.Contains("CTRL", result);
+    }
+
+    [Fact]
+    public async Task PressKey_UnknownKey_ReturnsError()
+    {
+        var tool = new PressKeyTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { key = "nonexistent_key" });
+        _output.WriteLine($"Result: {result}");
+        Assert.Contains("Unknown key", result);
+    }
+
+    [Fact]
+    public async Task PressKey_UnknownModifier_ReturnsError()
+    {
+        var tool = new PressKeyTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { key = "a", modifiers = new[] { "super" } });
+        _output.WriteLine($"Result: {result}");
+        Assert.Contains("Unknown modifier", result);
+    }
+
+    [Fact]
+    public async Task PressKey_WithRef_FocusesElement()
+    {
+        // Navigate to Forms tab and find the Name text box
+        var snapshot = _fixture.TakeSnapshot(_fixture.WinFormsHandle);
+        var tabRef = TestAppFixture.FindRefInSnapshot(snapshot, "Forms");
+        Assert.NotNull(tabRef);
+
+        var clickTool = new ClickTool(_fixture.Elements);
+        await _fixture.CallTool(clickTool, new { @ref = tabRef });
+
+        // Poll for the Name text box to appear
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        string? nameRef = null;
+        while (sw.ElapsedMilliseconds < 5000)
+        {
+            await Task.Delay(100);
+            nameRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Name");
+            if (nameRef != null) break;
+        }
+        Assert.NotNull(nameRef);
+
+        // Clear the field first
+        var fillTool = new FillTool(_fixture.Elements);
+        await _fixture.CallTool(fillTool, new { @ref = nameRef, value = "" });
+
+        // Press 'a' with ref to focus the Name text box
+        var tool = new PressKeyTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { key = "a", @ref = nameRef });
+        _output.WriteLine($"Press result: {result}");
+        Assert.Contains("focused", result);
+
+        // Verify the character was typed
+        var textTool = new GetTextTool(_fixture.Elements);
+        var text = await _fixture.CallTool(textTool, new { @ref = nameRef });
+        _output.WriteLine($"Text after press: '{text}'");
+        Assert.Equal("a", text);
+
+        // Clean up
+        await _fixture.CallTool(fillTool, new { @ref = nameRef, value = "" });
+    }
+
+    [Fact]
+    public async Task PressKey_Escape()
+    {
+        var tool = new PressKeyTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { key = "Escape" });
+        _output.WriteLine($"Result: {result}");
+        Assert.Contains("Pressed", result);
+        Assert.Contains("Escape", result);
+    }
+
+    [Fact]
+    public async Task PressKey_FunctionKey()
+    {
+        var tool = new PressKeyTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { key = "F5" });
+        _output.WriteLine($"Result: {result}");
+        Assert.Contains("Pressed", result);
+        Assert.Contains("F5", result);
+    }
+
+    [Fact]
+    public async Task PressKey_MultipleModifiers()
+    {
+        var tool = new PressKeyTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { key = "s", modifiers = new[] { "ctrl", "shift" } });
+        _output.WriteLine($"Result: {result}");
+        Assert.Contains("Pressed", result);
+        Assert.Contains("CTRL", result);
+        Assert.Contains("SHIFT", result);
+    }
+}

--- a/tests/FlaUI.Mcp.IntegrationTests/PressKeyTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/PressKeyTests.cs
@@ -51,7 +51,7 @@ public class PressKeyTests
     public async Task PressKey_UnknownModifier_ReturnsError()
     {
         var tool = new PressKeyTool(_fixture.Elements);
-        var result = await _fixture.CallTool(tool, new { key = "a", modifiers = new[] { "super" } });
+        var result = await _fixture.CallTool(tool, new { key = "a", modifiers = new[] { "hyper" } });
         _output.WriteLine($"Result: {result}");
         Assert.Contains("Unknown modifier", result);
     }


### PR DESCRIPTION
## Summary
- Adds `windows_press_key` tool for sending individual key presses and key combinations
- Supports named keys (Enter, Escape, Tab, arrow keys, F1-F12), single characters, and symbols
- Supports modifier combinations (Ctrl, Shift, Alt)
- Optional `ref` parameter to focus an element before pressing
- Uses async/await (not Thread.Sleep)

## Tests
8 integration tests: single key, modifier, multiple modifiers, function key, ref focus + verify typed character, escape, error cases (unknown key, unknown modifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)