### PR TITLE
Add windows_get_value tool for reading element values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `windows_get_value` tool for reading programmatic element values (Value pattern, Toggle state, SelectionItem, RangeValue)
 - **Integration test framework** with purpose-built WinForms (.NET Framework 4.8.1) and WPF (.NET 8) test applications
   - WinFormsTestApp: buttons, forms, 50-row DataGridView, TreeView, dialog launchers
   - WpfTestApp: equivalent WPF controls for cross-framework validation

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Or using `dotnet run`:
 | `windows_type` | Type text into an element |
 | `windows_fill` | Clear and fill a text field |
 | `windows_get_text` | Get text content of an element |
+| `windows_get_value` | Get programmatic value (input values, toggle state, selection state) |
 | `windows_screenshot` | Capture window/element as PNG |
 | `windows_list_windows` | List all open windows |
 | `windows_focus` | Bring a window to foreground |

--- a/src/FlaUI.Mcp/Program.cs
+++ b/src/FlaUI.Mcp/Program.cs
@@ -14,6 +14,7 @@ toolRegistry.RegisterTool(new ClickTool(elementRegistry));
 toolRegistry.RegisterTool(new TypeTool(elementRegistry));
 toolRegistry.RegisterTool(new FillTool(elementRegistry));
 toolRegistry.RegisterTool(new GetTextTool(elementRegistry));
+toolRegistry.RegisterTool(new GetValueTool(elementRegistry));
 toolRegistry.RegisterTool(new ScreenshotTool(sessionManager, elementRegistry));
 toolRegistry.RegisterTool(new ListWindowsTool(sessionManager));
 toolRegistry.RegisterTool(new FocusWindowTool(sessionManager));

--- a/src/FlaUI.Mcp/Tools/GetValueTool.cs
+++ b/src/FlaUI.Mcp/Tools/GetValueTool.cs
@@ -1,0 +1,100 @@
+using System.Text.Json;
+using FlaUI.Core.Definitions;
+using PlaywrightWindows.Mcp.Core;
+
+namespace PlaywrightWindows.Mcp.Tools;
+
+/// <summary>
+/// Get the programmatic value of an element (Value pattern, Toggle state, Selection state, RangeValue, etc.)
+/// </summary>
+public class GetValueTool : ToolBase
+{
+    private readonly ElementRegistry _elementRegistry;
+
+    public GetValueTool(ElementRegistry elementRegistry)
+    {
+        _elementRegistry = elementRegistry;
+    }
+
+    public override string Name => "windows_get_value";
+
+    public override string Description =>
+        "Get the programmatic value of an element. Reads the Value pattern for inputs, " +
+        "Toggle state for checkboxes, Selection state for list items, and RangeValue for " +
+        "sliders/progress bars. Distinct from windows_get_text which returns display text.";
+
+    public override object InputSchema => new
+    {
+        type = "object",
+        properties = new
+        {
+            @ref = new
+            {
+                type = "string",
+                description = "Element ref from windows_snapshot (e.g., 'w1e5')"
+            }
+        },
+        required = new[] { "ref" }
+    };
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var refId = GetStringArgument(arguments, "ref");
+        if (string.IsNullOrEmpty(refId))
+        {
+            return Task.FromResult(ErrorResult("Missing required argument: ref"));
+        }
+
+        var element = _elementRegistry.GetElement(refId);
+        if (element == null)
+        {
+            return Task.FromResult(ErrorResult($"Element not found: {refId}. Run windows_snapshot to refresh element refs."));
+        }
+
+        try
+        {
+            // 1. Value pattern (text inputs, combo boxes, etc.)
+            if (element.Patterns.Value.IsSupported)
+            {
+                var value = element.Patterns.Value.Pattern.Value.ValueOrDefault ?? "";
+                return Task.FromResult(TextResult(value));
+            }
+
+            // 2. Toggle pattern (checkboxes, toggle buttons)
+            if (element.Patterns.Toggle.IsSupported)
+            {
+                var toggleState = element.Patterns.Toggle.Pattern.ToggleState.ValueOrDefault;
+                var stateText = toggleState switch
+                {
+                    ToggleState.On => "checked",
+                    ToggleState.Off => "unchecked",
+                    ToggleState.Indeterminate => "indeterminate",
+                    _ => toggleState.ToString()
+                };
+                return Task.FromResult(TextResult(stateText));
+            }
+
+            // 3. SelectionItem pattern (list items, radio buttons)
+            if (element.Patterns.SelectionItem.IsSupported)
+            {
+                var isSelected = element.Patterns.SelectionItem.Pattern.IsSelected.ValueOrDefault;
+                return Task.FromResult(TextResult(isSelected ? "selected" : "unselected"));
+            }
+
+            // 4. RangeValue pattern (sliders, progress bars, spinners)
+            if (element.Patterns.RangeValue.IsSupported)
+            {
+                var rangeValue = element.Patterns.RangeValue.Pattern.Value.ValueOrDefault;
+                return Task.FromResult(TextResult(rangeValue.ToString()));
+            }
+
+            // 5. Fall back to Name property
+            var name = element.Properties.Name.ValueOrDefault ?? "";
+            return Task.FromResult(TextResult(name));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ErrorResult($"Failed to get value from {refId}: {ex.Message}"));
+        }
+    }
+}

--- a/src/FlaUI.Mcp/Tools/GetValueTool.cs
+++ b/src/FlaUI.Mcp/Tools/GetValueTool.cs
@@ -85,7 +85,7 @@ public class GetValueTool : ToolBase
             if (element.Patterns.RangeValue.IsSupported)
             {
                 var rangeValue = element.Patterns.RangeValue.Pattern.Value.ValueOrDefault;
-                return Task.FromResult(TextResult(rangeValue.ToString()));
+                return Task.FromResult(TextResult(rangeValue.ToString(System.Globalization.CultureInfo.InvariantCulture)));
             }
 
             // 5. Fall back to Name property

--- a/tests/FlaUI.Mcp.IntegrationTests/GetValueTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/GetValueTests.cs
@@ -1,0 +1,203 @@
+using System.Diagnostics;
+using PlaywrightWindows.Mcp.Tools;
+using Xunit.Abstractions;
+
+namespace FlaUI.Mcp.IntegrationTests;
+
+/// <summary>
+/// Tests for windows_get_value tool using the test apps.
+/// Tests each value source: Value pattern, Toggle, SelectionItem, RangeValue, and Name fallback.
+/// </summary>
+[Collection("TestApps")]
+public class GetValueTests
+{
+    private readonly TestAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public GetValueTests(TestAppFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    private async Task<string> NavigateToTabAndFind(string handle, string tabName, string elementName)
+    {
+        var snapshot = _fixture.TakeSnapshot(handle);
+        var tabRef = TestAppFixture.FindRefInSnapshot(snapshot, tabName);
+        Assert.NotNull(tabRef);
+
+        var clickTool = new ClickTool(_fixture.Elements);
+        await _fixture.CallTool(clickTool, new { @ref = tabRef });
+
+        var sw = Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < 5000)
+        {
+            await Task.Delay(100);
+            var found = _fixture.FindRefByName(handle, elementName);
+            if (found != null) return found;
+        }
+
+        Assert.Fail($"Element \"{elementName}\" not found after navigating to \"{tabName}\" tab.");
+        return "";
+    }
+
+    [Fact]
+    public async Task GetValue_TextBox_ReturnsValuePattern()
+    {
+        var nameRef = await NavigateToTabAndFind(_fixture.WinFormsHandle, "Forms", "Name");
+
+        // Fill a value first
+        var fillTool = new FillTool(_fixture.Elements);
+        await _fixture.CallTool(fillTool, new { @ref = nameRef, value = "Test Value" });
+
+        // Get value should return it via Value pattern
+        var tool = new GetValueTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { @ref = nameRef });
+        _output.WriteLine($"TextBox value: '{result}'");
+        Assert.Equal("Test Value", result);
+
+        // Clean up
+        await _fixture.CallTool(fillTool, new { @ref = nameRef, value = "" });
+    }
+
+    [Fact]
+    public async Task GetValue_ReadOnlyTextBox_ReturnsValue()
+    {
+        var resultRef = await NavigateToTabAndFind(_fixture.WinFormsHandle, "Forms", "Result");
+
+        var tool = new GetValueTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { @ref = resultRef });
+        _output.WriteLine($"ReadOnly TextBox value: '{result}'");
+        Assert.Equal("Computed value here", result);
+    }
+
+    [Fact]
+    public async Task GetValue_Checkbox_ReturnsToggleState()
+    {
+        // Navigate to Buttons tab and find the checkbox
+        var snapshot = _fixture.TakeSnapshot(_fixture.WinFormsHandle);
+        var tabRef = TestAppFixture.FindRefInSnapshot(snapshot, "Buttons");
+        Assert.NotNull(tabRef);
+
+        var clickTool = new ClickTool(_fixture.Elements);
+        await _fixture.CallTool(clickTool, new { @ref = tabRef });
+        await Task.Delay(100);
+
+        var cbRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Enable the button below");
+        Assert.NotNull(cbRef);
+
+        var tool = new GetValueTool(_fixture.Elements);
+
+        // Should be unchecked initially
+        var result1 = await _fixture.CallTool(tool, new { @ref = cbRef });
+        _output.WriteLine($"Checkbox value (before): '{result1}'");
+        Assert.Equal("unchecked", result1);
+
+        // Toggle it
+        await _fixture.CallTool(clickTool, new { @ref = cbRef });
+        await Task.Delay(100);
+
+        // Re-find after state change
+        cbRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Enable the button below");
+        Assert.NotNull(cbRef);
+
+        var result2 = await _fixture.CallTool(tool, new { @ref = cbRef });
+        _output.WriteLine($"Checkbox value (after): '{result2}'");
+        Assert.Equal("checked", result2);
+
+        // Toggle back
+        await _fixture.CallTool(clickTool, new { @ref = cbRef });
+    }
+
+    [Fact]
+    public async Task GetValue_RadioButton_ReturnsSelectionState()
+    {
+        // Navigate to Buttons tab
+        var snapshot = _fixture.TakeSnapshot(_fixture.WinFormsHandle);
+        var tabRef = TestAppFixture.FindRefInSnapshot(snapshot, "Buttons");
+        Assert.NotNull(tabRef);
+
+        var clickTool = new ClickTool(_fixture.Elements);
+        await _fixture.CallTool(clickTool, new { @ref = tabRef });
+        await Task.Delay(100);
+
+        var radioARef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Option A");
+        var radioBRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Option B");
+        Assert.NotNull(radioARef);
+        Assert.NotNull(radioBRef);
+
+        var tool = new GetValueTool(_fixture.Elements);
+
+        var resultA = await _fixture.CallTool(tool, new { @ref = radioARef });
+        _output.WriteLine($"Radio A value: '{resultA}'");
+
+        var resultB = await _fixture.CallTool(tool, new { @ref = radioBRef });
+        _output.WriteLine($"Radio B value: '{resultB}'");
+
+        // One should be selected, the other not
+        Assert.True(
+            (resultA == "selected" && resultB == "unselected") ||
+            (resultA == "checked" && resultB == "unchecked"),
+            $"Expected one selected/checked and one not. Got A='{resultA}', B='{resultB}'");
+    }
+
+    [Fact]
+    public async Task GetValue_Slider_ReturnsRangeValue()
+    {
+        var sliderRef = await NavigateToTabAndFind(_fixture.WinFormsHandle, "Forms", "Volume");
+
+        var tool = new GetValueTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { @ref = sliderRef });
+        _output.WriteLine($"Slider value: '{result}'");
+
+        // Slider is initialized to 50
+        Assert.Equal("50", result);
+    }
+
+    [Fact]
+    public async Task GetValue_Button_FallsBackToName()
+    {
+        // Navigate to Buttons tab to ensure the button is visible
+        var snapshot = _fixture.TakeSnapshot(_fixture.WinFormsHandle);
+        var tabRef = TestAppFixture.FindRefInSnapshot(snapshot, "Buttons");
+        Assert.NotNull(tabRef);
+        var clickTool = new ClickTool(_fixture.Elements);
+        await _fixture.CallTool(clickTool, new { @ref = tabRef });
+        await Task.Delay(100);
+
+        var buttonRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Click Me");
+        Assert.NotNull(buttonRef);
+
+        var tool = new GetValueTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { @ref = buttonRef });
+        _output.WriteLine($"Button value (name fallback): '{result}'");
+        Assert.Equal("Click Me", result);
+    }
+
+    [Fact]
+    public async Task GetValue_InvalidRef_ReturnsError()
+    {
+        var tool = new GetValueTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { @ref = "w999e999" });
+        _output.WriteLine($"Invalid ref result: '{result}'");
+        Assert.Contains("Element not found", result);
+    }
+
+    [Fact]
+    public async Task GetValue_Wpf_TextBox_ReturnsValue()
+    {
+        var nameRef = await NavigateToTabAndFind(_fixture.WpfHandle, "Forms", "Name");
+
+        // Fill a value
+        var fillTool = new FillTool(_fixture.Elements);
+        await _fixture.CallTool(fillTool, new { @ref = nameRef, value = "WPF Test" });
+
+        var tool = new GetValueTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { @ref = nameRef });
+        _output.WriteLine($"WPF TextBox value: '{result}'");
+        Assert.Equal("WPF Test", result);
+
+        // Clean up
+        await _fixture.CallTool(fillTool, new { @ref = nameRef, value = "" });
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `windows_get_value` tool that reads programmatic values from UI elements
- Priority: Value pattern → Toggle state → SelectionItem → RangeValue → Name fallback
- Distinct from `windows_get_text` which focuses on display text

## Tests
8 integration tests: text box (Value pattern), read-only text box, checkbox (checked/unchecked), radio button (selected/unselected), slider (RangeValue), button (Name fallback), invalid ref error, WPF cross-framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)