### PR TITLE
Add windows_find tool for targeted element discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - WpfTestApp: equivalent WPF controls for cross-framework validation
   - 13 integration tests covering snapshot, click, and text tools
   - Shared test fixture for stable window handles across test runs
+- `windows_find` tool for targeted element discovery by name, automationId, role, or UIA pattern
+
+### Fixed
+- `windows_find` refreshes window reference to avoid stale cached element properties
 
 ## [0.1.0] - 2024-02-02
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Or using `dotnet run`:
 | `windows_focus` | Bring a window to foreground |
 | `windows_close` | Close a window |
 | `windows_batch` | Execute multiple actions in one call |
+| `windows_find` | Search for elements by name, automationId, role, or pattern |
 
 ## How It Works
 

--- a/src/FlaUI.Mcp/Core/SnapshotBuilder.cs
+++ b/src/FlaUI.Mcp/Core/SnapshotBuilder.cs
@@ -62,7 +62,14 @@ public class SnapshotBuilder
         }
     }
 
-    private string BuildElementLine(AutomationElement element, string refId, string? name, string role)
+    public static string FormatElementLine(AutomationElement element, string refId)
+    {
+        var name = GetElementName(element);
+        var role = GetElementRole(element);
+        return BuildElementLine(element, refId, name, role);
+    }
+
+    private static string BuildElementLine(AutomationElement element, string refId, string? name, string role)
     {
         var parts = new List<string>();
 
@@ -88,7 +95,7 @@ public class SnapshotBuilder
         return string.Join(" ", parts);
     }
 
-    private string GetElementRole(AutomationElement element)
+    public static string GetElementRole(AutomationElement element)
     {
         try
         {
@@ -141,7 +148,7 @@ public class SnapshotBuilder
         }
     }
 
-    private string? GetElementName(AutomationElement element)
+    public static string? GetElementName(AutomationElement element)
     {
         try
         {
@@ -163,7 +170,7 @@ public class SnapshotBuilder
         }
     }
 
-    private List<string> GetStateIndicators(AutomationElement element)
+    public static List<string> GetStateIndicators(AutomationElement element)
     {
         var states = new List<string>();
 
@@ -246,7 +253,7 @@ public class SnapshotBuilder
         return false;
     }
 
-    private string EscapeName(string name)
+    public static string EscapeName(string name)
     {
         return name
             .Replace("\\", "\\\\")

--- a/src/FlaUI.Mcp/Program.cs
+++ b/src/FlaUI.Mcp/Program.cs
@@ -10,6 +10,7 @@ var elementRegistry = new ElementRegistry();
 var toolRegistry = new ToolRegistry();
 toolRegistry.RegisterTool(new LaunchTool(sessionManager));
 toolRegistry.RegisterTool(new SnapshotTool(sessionManager, elementRegistry));
+toolRegistry.RegisterTool(new FindTool(sessionManager, elementRegistry));
 toolRegistry.RegisterTool(new ClickTool(elementRegistry));
 toolRegistry.RegisterTool(new TypeTool(elementRegistry));
 toolRegistry.RegisterTool(new FillTool(elementRegistry));

--- a/src/FlaUI.Mcp/Tools/FindTool.cs
+++ b/src/FlaUI.Mcp/Tools/FindTool.cs
@@ -1,0 +1,287 @@
+using System.Text;
+using System.Text.Json;
+using FlaUI.Core.AutomationElements;
+using PlaywrightWindows.Mcp.Core;
+
+namespace PlaywrightWindows.Mcp.Tools;
+
+/// <summary>
+/// Search for elements matching criteria, returning only matching elements instead of the full tree
+/// </summary>
+public class FindTool : ToolBase
+{
+    private readonly SessionManager _sessionManager;
+    private readonly ElementRegistry _elementRegistry;
+
+    public FindTool(SessionManager sessionManager, ElementRegistry elementRegistry)
+    {
+        _sessionManager = sessionManager;
+        _elementRegistry = elementRegistry;
+    }
+
+    public override string Name => "windows_find";
+
+    public override string Description =>
+        "Search for UI elements matching criteria. Returns matching elements with refs that can be used " +
+        "with other tools. More targeted than windows_snapshot - use when you know what you're looking for.";
+
+    public override object InputSchema => new
+    {
+        type = "object",
+        properties = new
+        {
+            handle = new
+            {
+                type = "string",
+                description = "Window handle from windows_launch or windows_list_windows. If omitted, uses the focused window."
+            },
+            name = new
+            {
+                type = "string",
+                description = "Substring match on element Name property (case-insensitive)"
+            },
+            automationId = new
+            {
+                type = "string",
+                description = "Exact match on AutomationId"
+            },
+            role = new
+            {
+                type = "string",
+                description = "Filter by role (e.g., \"button\", \"textbox\", \"table\", \"checkbox\")"
+            },
+            depth = new
+            {
+                type = "integer",
+                description = "Max traversal depth (default: 10)"
+            },
+            pattern = new
+            {
+                type = "string",
+                description = "Filter by supported UIA pattern: \"invoke\", \"value\", \"toggle\", \"selection\", \"expandcollapse\", \"scroll\", \"grid\", \"table\", \"text\", \"rangevalue\"",
+                @enum = new[] { "invoke", "value", "toggle", "selection", "expandcollapse", "scroll", "grid", "table", "text", "rangevalue" }
+            }
+        }
+    };
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var handle = GetStringArgument(arguments, "handle");
+        var nameFilter = GetStringArgument(arguments, "name");
+        var automationIdFilter = GetStringArgument(arguments, "automationId");
+        var roleFilter = GetStringArgument(arguments, "role");
+        var depthArg = GetArgument<int?>(arguments, "depth");
+        var patternFilter = GetStringArgument(arguments, "pattern");
+
+        int maxDepth = depthArg ?? 10;
+
+        try
+        {
+            FlaUI.Core.AutomationElements.Window? window = null;
+
+            if (!string.IsNullOrEmpty(handle))
+            {
+                window = _sessionManager.GetWindow(handle);
+                if (window == null)
+                {
+                    return Task.FromResult(ErrorResult($"Window not found: {handle}"));
+                }
+            }
+            else
+            {
+                // Get the foreground window (same logic as SnapshotTool)
+                var focusedElement = _sessionManager.Automation.FocusedElement();
+
+                if (focusedElement != null)
+                {
+                    var current = focusedElement;
+                    while (current != null)
+                    {
+                        if (current.Properties.ControlType.ValueOrDefault == FlaUI.Core.Definitions.ControlType.Window)
+                        {
+                            window = current.AsWindow();
+                            break;
+                        }
+                        current = current.Parent;
+                    }
+                }
+
+                if (window == null)
+                {
+                    return Task.FromResult(ErrorResult("No window specified and no focused window found. Use windows_list_windows to see available windows."));
+                }
+
+                handle = _sessionManager.RegisterWindow(window);
+            }
+
+            // Validate pattern filter if provided
+            if (!string.IsNullOrEmpty(patternFilter) && !IsValidPattern(patternFilter))
+            {
+                return Task.FromResult(ErrorResult($"Unknown pattern: {patternFilter}. Valid patterns: invoke, value, toggle, selection, expandcollapse, scroll, grid, table, text, rangevalue"));
+            }
+
+            var matches = new List<(AutomationElement Element, string RefId)>();
+            FindMatchingElements(handle!, window, matches, nameFilter, automationIdFilter, roleFilter, patternFilter, 0, maxDepth);
+
+            if (matches.Count == 0)
+            {
+                return Task.FromResult(TextResult("No matching elements found."));
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Found {matches.Count} matching element(s):");
+            foreach (var (element, refId) in matches)
+            {
+                var line = SnapshotBuilder.FormatElementLine(element, refId);
+                sb.AppendLine($"- {line}");
+            }
+
+            return Task.FromResult(TextResult(sb.ToString()));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ErrorResult($"Find failed: {ex.Message}"));
+        }
+    }
+
+    private void FindMatchingElements(
+        string windowHandle,
+        AutomationElement element,
+        List<(AutomationElement, string)> matches,
+        string? nameFilter,
+        string? automationIdFilter,
+        string? roleFilter,
+        string? patternFilter,
+        int currentDepth,
+        int maxDepth)
+    {
+        if (currentDepth > maxDepth) return;
+
+        if (MatchesCriteria(element, nameFilter, automationIdFilter, roleFilter, patternFilter))
+        {
+            var refId = _elementRegistry.Register(windowHandle, element);
+            matches.Add((element, refId));
+        }
+
+        // Recurse into children
+        try
+        {
+            var children = element.FindAllChildren();
+            foreach (var child in children)
+            {
+                FindMatchingElements(windowHandle, child, matches, nameFilter, automationIdFilter, roleFilter, patternFilter, currentDepth + 1, maxDepth);
+            }
+        }
+        catch
+        {
+            // Some elements throw when accessing children
+        }
+    }
+
+    private static bool MatchesCriteria(
+        AutomationElement element,
+        string? nameFilter,
+        string? automationIdFilter,
+        string? roleFilter,
+        string? patternFilter)
+    {
+        // At least one filter must be specified (otherwise everything matches)
+        bool hasFilter = !string.IsNullOrEmpty(nameFilter)
+                      || !string.IsNullOrEmpty(automationIdFilter)
+                      || !string.IsNullOrEmpty(roleFilter)
+                      || !string.IsNullOrEmpty(patternFilter);
+        if (!hasFilter) return false;
+
+        // Name: substring match, case-insensitive
+        if (!string.IsNullOrEmpty(nameFilter))
+        {
+            try
+            {
+                var elementName = element.Properties.Name.ValueOrDefault;
+                if (string.IsNullOrEmpty(elementName) ||
+                    !elementName.Contains(nameFilter, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        // AutomationId: exact match
+        if (!string.IsNullOrEmpty(automationIdFilter))
+        {
+            try
+            {
+                var autoId = element.Properties.AutomationId.ValueOrDefault;
+                if (!string.Equals(autoId, automationIdFilter, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        // Role: match against the mapped role string
+        if (!string.IsNullOrEmpty(roleFilter))
+        {
+            var role = SnapshotBuilder.GetElementRole(element);
+            if (!string.Equals(role, roleFilter, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        // Pattern: check if the element supports the specified UIA pattern
+        if (!string.IsNullOrEmpty(patternFilter))
+        {
+            if (!SupportsPattern(element, patternFilter))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsValidPattern(string pattern)
+    {
+        return pattern.ToLowerInvariant() switch
+        {
+            "invoke" or "value" or "toggle" or "selection" or
+            "expandcollapse" or "scroll" or "grid" or "table" or
+            "text" or "rangevalue" => true,
+            _ => false
+        };
+    }
+
+    private static bool SupportsPattern(AutomationElement element, string pattern)
+    {
+        try
+        {
+            return pattern.ToLowerInvariant() switch
+            {
+                "invoke" => element.Patterns.Invoke.IsSupported,
+                "value" => element.Patterns.Value.IsSupported,
+                "toggle" => element.Patterns.Toggle.IsSupported,
+                "selection" => element.Patterns.SelectionItem.IsSupported,
+                "expandcollapse" => element.Patterns.ExpandCollapse.IsSupported,
+                "scroll" => element.Patterns.Scroll.IsSupported,
+                "grid" => element.Patterns.Grid.IsSupported,
+                "table" => element.Patterns.Table.IsSupported,
+                "text" => element.Patterns.Text.IsSupported,
+                "rangevalue" => element.Patterns.RangeValue.IsSupported,
+                _ => false
+            };
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/FlaUI.Mcp/Tools/FindTool.cs
+++ b/src/FlaUI.Mcp/Tools/FindTool.cs
@@ -86,6 +86,22 @@ public class FindTool : ToolBase
                 {
                     return Task.FromResult(ErrorResult($"Window not found: {handle}"));
                 }
+
+                // Re-find the window from desktop to get fresh element tree
+                // This avoids stale cached properties from a previous snapshot
+                try
+                {
+                    var desktop = _sessionManager.Automation.GetDesktop();
+                    var freshWindow = desktop.FindFirstDescendant(cf => cf.ByName(window.Title))?.AsWindow();
+                    if (freshWindow != null)
+                    {
+                        window = freshWindow;
+                    }
+                }
+                catch
+                {
+                    // Fall through to use the cached window if refresh fails
+                }
             }
             else
             {

--- a/src/FlaUI.Mcp/Tools/FindTool.cs
+++ b/src/FlaUI.Mcp/Tools/FindTool.cs
@@ -60,6 +60,11 @@ public class FindTool : ToolBase
                 type = "string",
                 description = "Filter by supported UIA pattern: \"invoke\", \"value\", \"toggle\", \"selection\", \"expandcollapse\", \"scroll\", \"grid\", \"table\", \"text\", \"rangevalue\"",
                 @enum = new[] { "invoke", "value", "toggle", "selection", "expandcollapse", "scroll", "grid", "table", "text", "rangevalue" }
+            },
+            maxResults = new
+            {
+                type = "integer",
+                description = "Maximum number of results to return (default: 50)"
             }
         }
     };
@@ -72,8 +77,10 @@ public class FindTool : ToolBase
         var roleFilter = GetStringArgument(arguments, "role");
         var depthArg = GetArgument<int?>(arguments, "depth");
         var patternFilter = GetStringArgument(arguments, "pattern");
+        var maxResultsArg = GetArgument<int?>(arguments, "maxResults");
 
         int maxDepth = depthArg ?? 10;
+        int maxResults = maxResultsArg ?? 50;
 
         try
         {
@@ -87,15 +94,19 @@ public class FindTool : ToolBase
                     return Task.FromResult(ErrorResult($"Window not found: {handle}"));
                 }
 
-                // Re-find the window from desktop to get fresh element tree
-                // This avoids stale cached properties from a previous snapshot
+                // Get a fresh UIA element via the native window handle to avoid
+                // stale cached properties from a previous snapshot
                 try
                 {
-                    var desktop = _sessionManager.Automation.GetDesktop();
-                    var freshWindow = desktop.FindFirstDescendant(cf => cf.ByName(window.Title))?.AsWindow();
-                    if (freshWindow != null)
+                    var hwnd = window.Properties.NativeWindowHandle.ValueOrDefault;
+                    if (hwnd != IntPtr.Zero)
                     {
-                        window = freshWindow;
+                        var freshElement = _sessionManager.Automation.FromHandle(hwnd);
+                        var freshWindow = freshElement?.AsWindow();
+                        if (freshWindow != null)
+                        {
+                            window = freshWindow;
+                        }
                     }
                 }
                 catch
@@ -137,7 +148,7 @@ public class FindTool : ToolBase
             }
 
             var matches = new List<(AutomationElement Element, string RefId)>();
-            FindMatchingElements(handle!, window, matches, nameFilter, automationIdFilter, roleFilter, patternFilter, 0, maxDepth);
+            FindMatchingElements(handle!, window, matches, nameFilter, automationIdFilter, roleFilter, patternFilter, 0, maxDepth, maxResults);
 
             if (matches.Count == 0)
             {
@@ -145,7 +156,10 @@ public class FindTool : ToolBase
             }
 
             var sb = new StringBuilder();
-            sb.AppendLine($"Found {matches.Count} matching element(s):");
+            var truncated = matches.Count >= maxResults;
+            sb.AppendLine(truncated
+                ? $"Found {matches.Count}+ matching element(s) (limit {maxResults}):"
+                : $"Found {matches.Count} matching element(s):");
             foreach (var (element, refId) in matches)
             {
                 var line = SnapshotBuilder.FormatElementLine(element, refId);
@@ -169,14 +183,17 @@ public class FindTool : ToolBase
         string? roleFilter,
         string? patternFilter,
         int currentDepth,
-        int maxDepth)
+        int maxDepth,
+        int maxResults)
     {
         if (currentDepth > maxDepth) return;
+        if (matches.Count >= maxResults) return;
 
         if (MatchesCriteria(element, nameFilter, automationIdFilter, roleFilter, patternFilter))
         {
             var refId = _elementRegistry.Register(windowHandle, element);
             matches.Add((element, refId));
+            if (matches.Count >= maxResults) return;
         }
 
         // Recurse into children
@@ -185,7 +202,8 @@ public class FindTool : ToolBase
             var children = element.FindAllChildren();
             foreach (var child in children)
             {
-                FindMatchingElements(windowHandle, child, matches, nameFilter, automationIdFilter, roleFilter, patternFilter, currentDepth + 1, maxDepth);
+                FindMatchingElements(windowHandle, child, matches, nameFilter, automationIdFilter, roleFilter, patternFilter, currentDepth + 1, maxDepth, maxResults);
+                if (matches.Count >= maxResults) return;
             }
         }
         catch

--- a/tests/FlaUI.Mcp.IntegrationTests/FindTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/FindTests.cs
@@ -1,0 +1,147 @@
+using System.Diagnostics;
+using PlaywrightWindows.Mcp.Tools;
+using Xunit.Abstractions;
+
+namespace FlaUI.Mcp.IntegrationTests;
+
+/// <summary>
+/// Tests for windows_find tool using the test apps.
+/// </summary>
+[Collection("TestApps")]
+public class FindTests
+{
+    private readonly TestAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public FindTests(TestAppFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    [Fact]
+    public async Task Find_ByRole_ReturnsMatchingElements()
+    {
+        var tool = new FindTool(_fixture.Session, _fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { handle = _fixture.WinFormsHandle, role = "button", depth = 5 });
+        _output.WriteLine(result);
+
+        Assert.Contains("matching element", result);
+        Assert.Contains("Click Me", result);
+    }
+
+    [Fact]
+    public async Task Find_ByName_SubstringMatch()
+    {
+        var tool = new FindTool(_fixture.Session, _fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { handle = _fixture.WinFormsHandle, name = "Conditional" });
+        _output.WriteLine(result);
+
+        Assert.Contains("Conditional Button", result);
+    }
+
+    [Fact]
+    public async Task Find_ByNameAndRole_NarrowsResults()
+    {
+        var tool = new FindTool(_fixture.Session, _fixture.Elements);
+
+        // Find all buttons
+        var allButtons = await _fixture.CallTool(tool, new { handle = _fixture.WinFormsHandle, role = "button", depth = 5 });
+        var allCount = allButtons.Split('\n').Count(l => l.TrimStart().StartsWith("- "));
+
+        // Find buttons containing "Click"
+        var clickButtons = await _fixture.CallTool(tool, new { handle = _fixture.WinFormsHandle, name = "Click", role = "button" });
+        var clickCount = clickButtons.Split('\n').Count(l => l.TrimStart().StartsWith("- "));
+
+        _output.WriteLine($"All buttons: {allCount}, 'Click' buttons: {clickCount}");
+        Assert.True(clickCount < allCount, "Name filter should narrow results");
+        Assert.True(clickCount >= 1, "Should find at least one 'Click' button");
+    }
+
+    [Fact]
+    public async Task Find_ByRole_Checkbox()
+    {
+        // Navigate to Buttons tab first
+        var snapshot = _fixture.TakeSnapshot(_fixture.WinFormsHandle);
+        var tabRef = TestAppFixture.FindRefInSnapshot(snapshot, "Buttons");
+        Assert.NotNull(tabRef);
+        var clickTool = new ClickTool(_fixture.Elements);
+        await _fixture.CallTool(clickTool, new { @ref = tabRef });
+        await Task.Delay(100);
+
+        var tool = new FindTool(_fixture.Session, _fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { handle = _fixture.WinFormsHandle, role = "checkbox" });
+        _output.WriteLine(result);
+
+        Assert.Contains("Enable the button below", result);
+    }
+
+    [Fact]
+    public async Task Find_ByPattern_Toggle()
+    {
+        var tool = new FindTool(_fixture.Session, _fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { handle = _fixture.WinFormsHandle, pattern = "toggle" });
+        _output.WriteLine(result);
+
+        // Checkboxes support toggle pattern
+        Assert.Contains("matching element", result);
+    }
+
+    [Fact]
+    public async Task Find_ByDepth_LimitsTraversal()
+    {
+        var tool = new FindTool(_fixture.Session, _fixture.Elements);
+
+        // Depth 1: only immediate children of the window
+        var shallow = await _fixture.CallTool(tool, new { handle = _fixture.WinFormsHandle, role = "button", depth = 1 });
+        var shallowCount = shallow.Split('\n').Count(l => l.TrimStart().StartsWith("- "));
+
+        // Depth 10: full tree
+        var deep = await _fixture.CallTool(tool, new { handle = _fixture.WinFormsHandle, role = "button", depth = 10 });
+        var deepCount = deep.Split('\n').Count(l => l.TrimStart().StartsWith("- "));
+
+        _output.WriteLine($"Depth 1: {shallowCount} buttons, Depth 10: {deepCount} buttons");
+        Assert.True(deepCount >= shallowCount, "Deeper search should find at least as many elements");
+    }
+
+    [Fact]
+    public async Task Find_NoMatches_ReturnsMessage()
+    {
+        var tool = new FindTool(_fixture.Session, _fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { handle = _fixture.WinFormsHandle, name = "This Element Does Not Exist XYZ" });
+        _output.WriteLine(result);
+
+        Assert.Contains("No matching elements", result);
+    }
+
+    [Fact]
+    public async Task Find_RefsWorkWithOtherTools()
+    {
+        // Find a button, then click it using the returned ref
+        var tool = new FindTool(_fixture.Session, _fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { handle = _fixture.WinFormsHandle, name = "Click Me", role = "button" });
+        _output.WriteLine($"Find result: {result}");
+
+        // Extract ref from result
+        var refMatch = System.Text.RegularExpressions.Regex.Match(result, @"\[ref=(\w+)\]");
+        Assert.True(refMatch.Success, "Should contain a ref");
+        var foundRef = refMatch.Groups[1].Value;
+        _output.WriteLine($"Extracted ref: {foundRef}");
+
+        // Click it
+        var clickTool = new ClickTool(_fixture.Elements);
+        var clickResult = await _fixture.CallTool(clickTool, new { @ref = foundRef });
+        _output.WriteLine($"Click result: {clickResult}");
+        Assert.Contains("Invoked", clickResult);
+    }
+
+    [Fact]
+    public async Task Find_Wpf_ByRole()
+    {
+        var tool = new FindTool(_fixture.Session, _fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { handle = _fixture.WpfHandle, role = "button", depth = 5 });
+        _output.WriteLine(result);
+
+        Assert.Contains("Click Me", result);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `windows_find` tool for searching elements by name, automationId, role, depth, and UIA pattern
- Returns only matching elements with refs, avoiding full snapshot cost
- All criteria use AND logic
- Refreshes window reference from desktop before searching to avoid stale cached properties

## Tests
9 integration tests: role filter, name substring, combined name+role, checkbox discovery, pattern filter (toggle), depth limiting, no-match message, refs usable with other tools, WPF cross-framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)