### PR TITLE
Add windows_table tool for reading grid data as markdown tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - WpfTestApp: equivalent WPF controls for cross-framework validation
   - 13 integration tests covering snapshot, click, and text tools
   - Shared test fixture for stable window handles across test runs
+- `windows_table` tool for reading DataGridView and table data as markdown tables
+
+### Fixed
+- Column header detection for WinForms DataGridView controls
 
 ## [0.1.0] - 2024-02-02
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Or using `dotnet run`:
 | `windows_focus` | Bring a window to foreground |
 | `windows_close` | Close a window |
 | `windows_batch` | Execute multiple actions in one call |
+| `windows_table` | Read table/grid data as structured markdown |
 
 ## How It Works
 

--- a/src/FlaUI.Mcp/Program.cs
+++ b/src/FlaUI.Mcp/Program.cs
@@ -14,6 +14,7 @@ toolRegistry.RegisterTool(new ClickTool(elementRegistry));
 toolRegistry.RegisterTool(new TypeTool(elementRegistry));
 toolRegistry.RegisterTool(new FillTool(elementRegistry));
 toolRegistry.RegisterTool(new GetTextTool(elementRegistry));
+toolRegistry.RegisterTool(new TableTool(elementRegistry));
 toolRegistry.RegisterTool(new ScreenshotTool(sessionManager, elementRegistry));
 toolRegistry.RegisterTool(new ListWindowsTool(sessionManager));
 toolRegistry.RegisterTool(new FocusWindowTool(sessionManager));

--- a/src/FlaUI.Mcp/Tools/TableTool.cs
+++ b/src/FlaUI.Mcp/Tools/TableTool.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using FlaUI.Core.AutomationElements;
 using FlaUI.Core.Definitions;
 using PlaywrightWindows.Mcp.Core;
@@ -11,6 +12,8 @@ namespace PlaywrightWindows.Mcp.Tools;
 /// </summary>
 public class TableTool : ToolBase
 {
+    private const int DefaultMaxRows = 100;
+
     private readonly ElementRegistry _elementRegistry;
 
     public TableTool(ElementRegistry elementRegistry)
@@ -37,7 +40,7 @@ public class TableTool : ToolBase
             rows = new
             {
                 type = "string",
-                description = "Row range like '0-9', '0', '5-14'. Default: all rows."
+                description = "Row range like '0-9', '0', '5-14'. Default: first 100 rows."
             },
             columns = new
             {
@@ -75,31 +78,32 @@ public class TableTool : ToolBase
             var rowsParam = GetStringArgument(arguments, "rows");
             var columnsParam = GetStringArgument(arguments, "columns");
 
-            // Check if the table has standard DataItem rows (WPF/modern controls)
-            // or non-standard children (WinForms DataGridView uses Custom type for rows)
-            var hasDataItemRows = false;
-            try
-            {
-                var dataItems = element.FindAllChildren(c => c.ByControlType(ControlType.DataItem));
-                hasDataItemRows = dataItems.Length > 0;
-            }
-            catch { }
+            // Fetch children once and reuse across header detection and row reading
+            var allChildren = element.FindAllChildren();
 
-            // Use Grid pattern only if we have standard DataItem rows
-            if (hasDataItemRows && element.Patterns.Grid.IsSupported)
+            // Detect data rows: standard DataItem or WinForms "Row N" pattern
+            var dataRows = FindDataRows(allChildren);
+            int totalRows = dataRows.Length;
+
+            // Try Grid pattern for standard DataItem rows
+            if (dataRows.Length > 0
+                && dataRows[0].Properties.ControlType.ValueOrDefault == ControlType.DataItem
+                && element.Patterns.Grid.IsSupported)
             {
                 try
                 {
-                    return Task.FromResult(ReadViaGridPattern(element, rowsParam, columnsParam));
+                    return Task.FromResult(ReadViaGridPattern(
+                        element, allChildren, totalRows, rowsParam, columnsParam));
                 }
                 catch
                 {
-                    // Grid pattern may throw even with DataItem rows; fall through
+                    // Grid pattern may throw (e.g., ElementNotAvailableException); fall through
                 }
             }
 
-            // Fall back to generic tree walking that handles non-standard row types
-            return Task.FromResult(ReadViaTreeWalking(element, rowsParam, columnsParam));
+            // Tree walking handles both standard and non-standard row types
+            return Task.FromResult(ReadViaTreeWalking(
+                allChildren, dataRows, rowsParam, columnsParam));
         }
         catch (Exception ex)
         {
@@ -107,273 +111,256 @@ public class TableTool : ToolBase
         }
     }
 
-    private McpToolResult ReadViaGridPattern(AutomationElement element, string? rowsParam, string? columnsParam)
+    private static AutomationElement[] FindDataRows(AutomationElement[] allChildren)
     {
-        var gridPattern = element.Patterns.Grid.Pattern;
-        int totalRows = gridPattern.RowCount;
-        int totalCols = gridPattern.ColumnCount;
-
-        // Read headers from Header children
-        var headers = GetColumnHeaders(element, totalCols);
-
-        // Determine which columns to include
-        var (columnIndices, columnNames) = FilterColumns(headers, columnsParam, totalCols);
-
-        // Parse row range
-        var (startRow, endRow) = ParseRowRange(rowsParam, totalRows);
-
-        // Build markdown table
-        var sb = new StringBuilder();
-
-        // Header row
-        sb.Append('|');
-        foreach (var name in columnNames)
-        {
-            sb.Append($" {EscapePipe(name)} |");
-        }
-        sb.AppendLine();
-
-        // Separator row
-        sb.Append('|');
-        foreach (var _ in columnNames)
-        {
-            sb.Append(" --- |");
-        }
-        sb.AppendLine();
-
-        // Data rows
-        for (int row = startRow; row <= endRow && row < totalRows; row++)
-        {
-            sb.Append('|');
-            foreach (var col in columnIndices)
-            {
-                var cell = gridPattern.GetItem(row, col);
-                var value = GetCellValue(cell);
-                sb.Append($" {EscapePipe(value)} |");
-            }
-            sb.AppendLine();
-        }
-
-        int shownStart = startRow;
-        int shownEnd = Math.Min(endRow, totalRows - 1);
-        sb.AppendLine($"({totalRows} total rows, showing {shownStart}-{shownEnd})");
-
-        return TextResult(sb.ToString());
-    }
-
-    private McpToolResult ReadViaTreeWalking(AutomationElement element, string? rowsParam, string? columnsParam)
-    {
-        // Find data rows — try DataItem first, then fall back to any named "Row N" children
-        var allChildren = element.FindAllChildren();
-        var dataItems = allChildren
+        return allChildren
             .Where(c =>
             {
                 try
                 {
                     var ct = c.Properties.ControlType.ValueOrDefault;
                     if (ct == ControlType.DataItem) return true;
+                    if (ct == ControlType.Header || ct == ControlType.ScrollBar) return false;
                     // WinForms DataGridView uses Custom type with "Row N" names
                     var name = c.Properties.Name.ValueOrDefault ?? "";
-                    return name.StartsWith("Row ") && ct != ControlType.Header
-                        && ct != ControlType.ScrollBar;
+                    return Regex.IsMatch(name, @"^Row \d+$");
                 }
                 catch { return false; }
             })
             .ToArray();
-        int totalRows = dataItems.Length;
+    }
 
-        // Determine column count from the first data row's children (excluding row headers)
-        int totalCols = 0;
-        if (dataItems.Length > 0)
-        {
-            var firstRowChildren = dataItems[0].FindAllChildren();
-            // Exclude row header children (e.g., "Row 0" header in WinForms DataGridView)
-            totalCols = firstRowChildren.Count(c =>
-            {
-                try { return c.Properties.ControlType.ValueOrDefault != ControlType.Header; }
-                catch { return true; }
-            });
-        }
-
-        // Use the shared header detection logic
-        var headers = GetColumnHeaders(element, totalCols);
-
-        // Determine which columns to include
+    private McpToolResult ReadViaGridPattern(
+        AutomationElement element, AutomationElement[] allChildren, int totalRows,
+        string? rowsParam, string? columnsParam)
+    {
+        var gridPattern = element.Patterns.Grid.Pattern;
+        int totalCols = gridPattern.ColumnCount;
+        var headers = GetColumnHeaders(allChildren, totalCols);
         var (columnIndices, columnNames) = FilterColumns(headers, columnsParam, totalCols);
-
-        // Parse row range
         var (startRow, endRow) = ParseRowRange(rowsParam, totalRows);
 
-        // Build markdown table
+        // Build cell accessor for the grid pattern
+        string GetCell(int row, int col)
+        {
+            var cell = gridPattern.GetItem(row, col);
+            return cell != null ? GetCellValue(cell) : "";
+        }
+
+        return BuildMarkdownTable(columnNames, columnIndices, totalRows, startRow, endRow, GetCell);
+    }
+
+    private McpToolResult ReadViaTreeWalking(
+        AutomationElement[] allChildren, AutomationElement[] dataRows,
+        string? rowsParam, string? columnsParam)
+    {
+        int totalRows = dataRows.Length;
+
+        // Determine column count from first data row (excluding row headers)
+        int totalCols = 0;
+        AutomationElement[]? firstRowDataCells = null;
+        if (dataRows.Length > 0)
+        {
+            var firstRowChildren = dataRows[0].FindAllChildren();
+            firstRowDataCells = FilterDataCells(firstRowChildren);
+            totalCols = firstRowDataCells.Length;
+        }
+
+        var headers = GetColumnHeaders(allChildren, totalCols);
+        var (columnIndices, columnNames) = FilterColumns(headers, columnsParam, totalCols);
+        var (startRow, endRow) = ParseRowRange(rowsParam, totalRows);
+
+        // Cache cell arrays per row to avoid redundant FindAllChildren calls
+        // (first row already fetched above)
+        var rowCellCache = new Dictionary<int, AutomationElement[]>();
+        if (firstRowDataCells != null) rowCellCache[0] = firstRowDataCells;
+
+        string GetCell(int row, int col)
+        {
+            if (!rowCellCache.TryGetValue(row, out var cells))
+            {
+                cells = FilterDataCells(dataRows[row].FindAllChildren());
+                rowCellCache[row] = cells;
+            }
+            return col < cells.Length ? GetCellValue(cells[col]) : "";
+        }
+
+        return BuildMarkdownTable(columnNames, columnIndices, totalRows, startRow, endRow, GetCell);
+    }
+
+    /// <summary>
+    /// Filter out row header elements from a row's children, returning only data cells.
+    /// </summary>
+    private static AutomationElement[] FilterDataCells(AutomationElement[] rowChildren)
+    {
+        return rowChildren.Where(c =>
+        {
+            try { return c.Properties.ControlType.ValueOrDefault != ControlType.Header; }
+            catch { return true; }
+        }).ToArray();
+    }
+
+    /// <summary>
+    /// Shared markdown table builder used by both grid pattern and tree walking paths.
+    /// </summary>
+    private McpToolResult BuildMarkdownTable(
+        List<string> columnNames, List<int> columnIndices,
+        int totalRows, int startRow, int endRow,
+        Func<int, int, string> getCell)
+    {
         var sb = new StringBuilder();
 
         // Header row
         sb.Append('|');
         foreach (var name in columnNames)
-        {
             sb.Append($" {EscapePipe(name)} |");
-        }
         sb.AppendLine();
 
         // Separator row
         sb.Append('|');
         foreach (var _ in columnNames)
-        {
             sb.Append(" --- |");
-        }
         sb.AppendLine();
 
         // Data rows
         for (int row = startRow; row <= endRow && row < totalRows; row++)
         {
-            // Get data cells, excluding row header elements
-            var allCells = dataItems[row].FindAllChildren();
-            var dataCells = allCells.Where(c =>
-            {
-                try { return c.Properties.ControlType.ValueOrDefault != ControlType.Header; }
-                catch { return true; }
-            }).ToArray();
-
             sb.Append('|');
             foreach (var col in columnIndices)
-            {
-                var value = col < dataCells.Length ? GetCellValue(dataCells[col]) : "";
-                sb.Append($" {EscapePipe(value)} |");
-            }
+                sb.Append($" {EscapePipe(getCell(row, col))} |");
             sb.AppendLine();
         }
 
-        int shownStart = startRow;
         int shownEnd = Math.Min(endRow, totalRows - 1);
-        sb.AppendLine($"({totalRows} total rows, showing {shownStart}-{shownEnd})");
+        sb.AppendLine($"({totalRows} total rows, showing {startRow}-{shownEnd})");
 
         return TextResult(sb.ToString());
     }
 
-    private List<string> GetColumnHeaders(AutomationElement element, int totalCols)
+    // --- Header detection ---
+
+    private List<string> GetColumnHeaders(AutomationElement[] allChildren, int totalCols)
     {
         List<string> headers;
 
-        // Strategy 1: Find a Header container with HeaderItem children (standard WPF/Win32 tables)
-        headers = TryHeaderContainerWithHeaderItems(element);
+        // Strategy 1: Header container with HeaderItem children (standard WPF/Win32)
+        headers = TryHeaderContainerWithHeaderItems(allChildren);
         if (HasMeaningfulNames(headers))
             return PadHeaders(headers, totalCols);
 
-        // Strategy 2: Find the header row container and extract Header children
-        // (WinForms DataGridView has a "Top Row" element with Header children)
-        headers = TryHeaderRowContainer(element);
+        // Strategy 2: Header row container with Header children (WinForms DataGridView)
+        headers = TryHeaderRowContainer(allChildren);
         if (HasMeaningfulNames(headers))
             return PadHeaders(headers, totalCols);
 
-        // Strategy 3: Find HeaderItem descendants at any depth
-        headers = TryDescendantsByType(element, ControlType.HeaderItem);
+        // Strategy 3: Cell names from first DataItem row (last resort — names may be values)
+        headers = TryCellNamesFromFirstRow(allChildren);
         if (HasMeaningfulNames(headers))
             return PadHeaders(headers, totalCols);
 
-        // Strategy 4: Use cell names from the first DataItem row
-        headers = TryCellNamesFromFirstRow(element);
-        if (HasMeaningfulNames(headers))
-            return PadHeaders(headers, totalCols);
-
-        // Strategy 5: Fall back to generic Column0, Column1, etc.
-        headers = new List<string>();
-        return PadHeaders(headers, totalCols);
+        // Strategy 4: Generic Column0, Column1, etc.
+        return PadHeaders(new List<string>(), totalCols);
     }
 
-    private List<string> TryHeaderContainerWithHeaderItems(AutomationElement element)
+    private static List<string> TryHeaderContainerWithHeaderItems(AutomationElement[] allChildren)
     {
         var headers = new List<string>();
-        var headerElements = element.FindAllChildren(c =>
-            c.ByControlType(ControlType.Header));
-        if (headerElements.Length > 0)
+        foreach (var child in allChildren)
         {
-            var headerItems = headerElements[0].FindAllChildren(c =>
-                c.ByControlType(ControlType.HeaderItem));
-            foreach (var item in headerItems)
+            try
             {
-                headers.Add(item.Properties.Name.ValueOrDefault ?? "");
+                if (child.Properties.ControlType.ValueOrDefault != ControlType.Header)
+                    continue;
+                var headerItems = child.FindAllChildren(c => c.ByControlType(ControlType.HeaderItem));
+                foreach (var item in headerItems)
+                    headers.Add(item.Properties.Name.ValueOrDefault ?? "");
+                if (headers.Count > 0) return headers;
             }
+            catch { }
         }
         return headers;
     }
 
-    private List<string> TryHeaderRowContainer(AutomationElement element)
+    private static List<string> TryHeaderRowContainer(AutomationElement[] allChildren)
     {
-        // Look for a child element whose children are all Headers (the header row container).
-        // Skip the first header in each container if it's a corner cell (e.g., "Top Left Header Cell").
+        // Find a child whose children are mostly Headers (the column header row).
+        // The first such child before any data rows is the header container.
         var headers = new List<string>();
-        try
+        foreach (var child in allChildren)
         {
-            var children = element.FindAllChildren();
-            foreach (var child in children)
+            try
             {
-                try
-                {
-                    var ct = child.Properties.ControlType.ValueOrDefault;
-                    // Skip scrollbars and known non-header containers
-                    if (ct == ControlType.ScrollBar) continue;
+                var ct = child.Properties.ControlType.ValueOrDefault;
+                if (ct == ControlType.ScrollBar) continue;
 
-                    var grandchildren = child.FindAllChildren();
-                    if (grandchildren.Length == 0) continue;
+                // Stop searching once we hit data rows
+                var name = child.Properties.Name.ValueOrDefault ?? "";
+                if (ct == ControlType.DataItem || Regex.IsMatch(name, @"^Row \d+$"))
+                    break;
 
-                    // Check if most children are Headers (the header row)
-                    var headerChildren = grandchildren
-                        .Where(gc =>
-                        {
-                            try { return gc.Properties.ControlType.ValueOrDefault == ControlType.Header; }
-                            catch { return false; }
-                        })
-                        .ToArray();
+                var grandchildren = child.FindAllChildren();
+                if (grandchildren.Length < 2) continue;
 
-                    if (headerChildren.Length >= 2 && headerChildren.Length >= grandchildren.Length / 2)
+                var headerChildren = grandchildren
+                    .Where(gc =>
                     {
-                        // Found the header row — extract names, skip corner cell
-                        foreach (var h in headerChildren)
+                        try { return gc.Properties.ControlType.ValueOrDefault == ControlType.Header; }
+                        catch { return false; }
+                    })
+                    .ToArray();
+
+                if (headerChildren.Length >= 2 && headerChildren.Length >= grandchildren.Length / 2)
+                {
+                    // Skip the corner cell: first header with an empty name or generic name
+                    // that doesn't match subsequent header naming patterns
+                    bool skippedCorner = false;
+                    foreach (var h in headerChildren)
+                    {
+                        var hName = h.Properties.Name.ValueOrDefault ?? "";
+                        if (!skippedCorner && headers.Count == 0 && headerChildren.Length > 2)
                         {
-                            var name = h.Properties.Name.ValueOrDefault ?? "";
-                            // Skip the corner "Top Left Header Cell" or similar
-                            if (name.Contains("Top Left") || name.Contains("Header Cell"))
+                            // If the first header name looks like a corner cell (empty, or
+                            // doesn't match the pattern of subsequent headers), skip it
+                            var nextName = headerChildren.Length > 1
+                                ? headerChildren[1].Properties.Name.ValueOrDefault ?? ""
+                                : "";
+                            if (string.IsNullOrEmpty(hName) || hName.Length > nextName.Length * 3)
+                            {
+                                skippedCorner = true;
                                 continue;
-                            headers.Add(name);
+                            }
                         }
-                        if (headers.Count > 0) return headers;
+                        headers.Add(hName);
                     }
+                    if (headers.Count > 0) return headers;
                 }
-                catch { }
             }
-        }
-        catch { }
-        return headers;
-    }
-
-    private List<string> TryDescendantsByType(AutomationElement element, ControlType controlType)
-    {
-        var headers = new List<string>();
-        var descendants = element.FindAllDescendants(cf => cf.ByControlType(controlType));
-        foreach (var desc in descendants)
-        {
-            var name = desc.Properties.Name.ValueOrDefault ?? "";
-            headers.Add(name);
+            catch { }
         }
         return headers;
     }
 
-    private List<string> TryCellNamesFromFirstRow(AutomationElement element)
+    private static List<string> TryCellNamesFromFirstRow(AutomationElement[] allChildren)
     {
         var headers = new List<string>();
-        var dataItems = element.FindAllChildren(c =>
-            c.ByControlType(ControlType.DataItem));
-        if (dataItems.Length > 0)
+        foreach (var child in allChildren)
         {
-            var cells = dataItems[0].FindAllChildren();
-            foreach (var cell in cells)
+            try
             {
-                var name = cell.Properties.Name.ValueOrDefault ?? "";
-                headers.Add(name);
+                if (child.Properties.ControlType.ValueOrDefault == ControlType.DataItem)
+                {
+                    var cells = child.FindAllChildren();
+                    foreach (var cell in cells)
+                        headers.Add(cell.Properties.Name.ValueOrDefault ?? "");
+                    return headers;
+                }
             }
+            catch { }
         }
         return headers;
     }
+
+    // --- Helpers ---
 
     private static bool HasMeaningfulNames(List<string> headers)
     {
@@ -383,18 +370,16 @@ public class TableTool : ToolBase
     private static List<string> PadHeaders(List<string> headers, int totalCols)
     {
         while (headers.Count < totalCols)
-        {
             headers.Add($"Column{headers.Count}");
-        }
         return headers;
     }
 
-    private (List<int> indices, List<string> names) FilterColumns(List<string> allHeaders, string? columnsParam, int totalCols)
+    private static (List<int> indices, List<string> names) FilterColumns(
+        List<string> allHeaders, string? columnsParam, int totalCols)
     {
         if (string.IsNullOrEmpty(columnsParam))
         {
-            var allIndices = Enumerable.Range(0, totalCols).ToList();
-            return (allIndices, allHeaders.Take(totalCols).ToList());
+            return (Enumerable.Range(0, totalCols).ToList(), allHeaders.Take(totalCols).ToList());
         }
 
         var requestedNames = columnsParam.Split(',').Select(s => s.Trim()).ToList();
@@ -417,50 +402,43 @@ public class TableTool : ToolBase
         return (indices, names);
     }
 
-    private (int start, int end) ParseRowRange(string? rowsParam, int totalRows)
+    private static (int start, int end) ParseRowRange(string? rowsParam, int totalRows)
     {
         if (string.IsNullOrEmpty(rowsParam))
         {
-            return (0, totalRows - 1);
+            return (0, Math.Min(totalRows - 1, DefaultMaxRows - 1));
         }
 
         var parts = rowsParam.Split('-');
-        if (parts.Length == 1)
+        if (parts.Length == 1 && int.TryParse(parts[0].Trim(), out int single))
         {
-            if (int.TryParse(parts[0].Trim(), out int single))
-            {
-                return (single, single);
-            }
+            return (single, single);
         }
-        else if (parts.Length == 2)
+        if (parts.Length == 2
+            && int.TryParse(parts[0].Trim(), out int start)
+            && int.TryParse(parts[1].Trim(), out int end))
         {
-            if (int.TryParse(parts[0].Trim(), out int start) &&
-                int.TryParse(parts[1].Trim(), out int end))
-            {
-                return (start, end);
-            }
+            return (start, end);
         }
 
-        return (0, totalRows - 1);
+        return (0, Math.Min(totalRows - 1, DefaultMaxRows - 1));
     }
 
-    private string GetCellValue(AutomationElement cell)
+    private static string GetCellValue(AutomationElement? cell)
     {
+        if (cell == null) return "";
         try
         {
-            // Try Value pattern
             if (cell.Patterns.Value.IsSupported)
             {
                 var val = cell.Patterns.Value.Pattern.Value.ValueOrDefault;
                 if (!string.IsNullOrEmpty(val)) return val;
             }
-            // Try Toggle pattern for checkbox cells
             if (cell.Patterns.Toggle.IsSupported)
             {
                 var state = cell.Patterns.Toggle.Pattern.ToggleState.ValueOrDefault;
                 return state == ToggleState.On ? "[x]" : "[ ]";
             }
-            // Fall back to Name
             return cell.Properties.Name.ValueOrDefault ?? "";
         }
         catch { return ""; }

--- a/src/FlaUI.Mcp/Tools/TableTool.cs
+++ b/src/FlaUI.Mcp/Tools/TableTool.cs
@@ -75,13 +75,30 @@ public class TableTool : ToolBase
             var rowsParam = GetStringArgument(arguments, "rows");
             var columnsParam = GetStringArgument(arguments, "columns");
 
-            // Try Grid pattern first
-            if (element.Patterns.Grid.IsSupported)
+            // Check if the table has standard DataItem rows (WPF/modern controls)
+            // or non-standard children (WinForms DataGridView uses Custom type for rows)
+            var hasDataItemRows = false;
+            try
             {
-                return Task.FromResult(ReadViaGridPattern(element, rowsParam, columnsParam));
+                var dataItems = element.FindAllChildren(c => c.ByControlType(ControlType.DataItem));
+                hasDataItemRows = dataItems.Length > 0;
+            }
+            catch { }
+
+            // Use Grid pattern only if we have standard DataItem rows
+            if (hasDataItemRows && element.Patterns.Grid.IsSupported)
+            {
+                try
+                {
+                    return Task.FromResult(ReadViaGridPattern(element, rowsParam, columnsParam));
+                }
+                catch
+                {
+                    // Grid pattern may throw even with DataItem rows; fall through
+                }
             }
 
-            // Fall back to tree walking
+            // Fall back to generic tree walking that handles non-standard row types
             return Task.FromResult(ReadViaTreeWalking(element, rowsParam, columnsParam));
         }
         catch (Exception ex)
@@ -146,16 +163,36 @@ public class TableTool : ToolBase
 
     private McpToolResult ReadViaTreeWalking(AutomationElement element, string? rowsParam, string? columnsParam)
     {
-        // Find data rows
-        var dataItems = element.FindAllChildren(c =>
-            c.ByControlType(ControlType.DataItem));
+        // Find data rows — try DataItem first, then fall back to any named "Row N" children
+        var allChildren = element.FindAllChildren();
+        var dataItems = allChildren
+            .Where(c =>
+            {
+                try
+                {
+                    var ct = c.Properties.ControlType.ValueOrDefault;
+                    if (ct == ControlType.DataItem) return true;
+                    // WinForms DataGridView uses Custom type with "Row N" names
+                    var name = c.Properties.Name.ValueOrDefault ?? "";
+                    return name.StartsWith("Row ") && ct != ControlType.Header
+                        && ct != ControlType.ScrollBar;
+                }
+                catch { return false; }
+            })
+            .ToArray();
         int totalRows = dataItems.Length;
 
-        // Determine column count from the first data row if available
+        // Determine column count from the first data row's children (excluding row headers)
         int totalCols = 0;
         if (dataItems.Length > 0)
         {
-            totalCols = dataItems[0].FindAllChildren().Length;
+            var firstRowChildren = dataItems[0].FindAllChildren();
+            // Exclude row header children (e.g., "Row 0" header in WinForms DataGridView)
+            totalCols = firstRowChildren.Count(c =>
+            {
+                try { return c.Properties.ControlType.ValueOrDefault != ControlType.Header; }
+                catch { return true; }
+            });
         }
 
         // Use the shared header detection logic
@@ -189,11 +226,18 @@ public class TableTool : ToolBase
         // Data rows
         for (int row = startRow; row <= endRow && row < totalRows; row++)
         {
-            var cells = dataItems[row].FindAllChildren();
+            // Get data cells, excluding row header elements
+            var allCells = dataItems[row].FindAllChildren();
+            var dataCells = allCells.Where(c =>
+            {
+                try { return c.Properties.ControlType.ValueOrDefault != ControlType.Header; }
+                catch { return true; }
+            }).ToArray();
+
             sb.Append('|');
             foreach (var col in columnIndices)
             {
-                var value = col < cells.Length ? GetCellValue(cells[col]) : "";
+                var value = col < dataCells.Length ? GetCellValue(dataCells[col]) : "";
                 sb.Append($" {EscapePipe(value)} |");
             }
             sb.AppendLine();
@@ -215,9 +259,9 @@ public class TableTool : ToolBase
         if (HasMeaningfulNames(headers))
             return PadHeaders(headers, totalCols);
 
-        // Strategy 2: Find Header descendants at any depth (WinForms DataGridView uses
-        // ControlType.Header for individual column headers, not HeaderItem)
-        headers = TryDescendantsByType(element, ControlType.Header);
+        // Strategy 2: Find the header row container and extract Header children
+        // (WinForms DataGridView has a "Top Row" element with Header children)
+        headers = TryHeaderRowContainer(element);
         if (HasMeaningfulNames(headers))
             return PadHeaders(headers, totalCols);
 
@@ -250,6 +294,55 @@ public class TableTool : ToolBase
                 headers.Add(item.Properties.Name.ValueOrDefault ?? "");
             }
         }
+        return headers;
+    }
+
+    private List<string> TryHeaderRowContainer(AutomationElement element)
+    {
+        // Look for a child element whose children are all Headers (the header row container).
+        // Skip the first header in each container if it's a corner cell (e.g., "Top Left Header Cell").
+        var headers = new List<string>();
+        try
+        {
+            var children = element.FindAllChildren();
+            foreach (var child in children)
+            {
+                try
+                {
+                    var ct = child.Properties.ControlType.ValueOrDefault;
+                    // Skip scrollbars and known non-header containers
+                    if (ct == ControlType.ScrollBar) continue;
+
+                    var grandchildren = child.FindAllChildren();
+                    if (grandchildren.Length == 0) continue;
+
+                    // Check if most children are Headers (the header row)
+                    var headerChildren = grandchildren
+                        .Where(gc =>
+                        {
+                            try { return gc.Properties.ControlType.ValueOrDefault == ControlType.Header; }
+                            catch { return false; }
+                        })
+                        .ToArray();
+
+                    if (headerChildren.Length >= 2 && headerChildren.Length >= grandchildren.Length / 2)
+                    {
+                        // Found the header row — extract names, skip corner cell
+                        foreach (var h in headerChildren)
+                        {
+                            var name = h.Properties.Name.ValueOrDefault ?? "";
+                            // Skip the corner "Top Left Header Cell" or similar
+                            if (name.Contains("Top Left") || name.Contains("Header Cell"))
+                                continue;
+                            headers.Add(name);
+                        }
+                        if (headers.Count > 0) return headers;
+                    }
+                }
+                catch { }
+            }
+        }
+        catch { }
         return headers;
     }
 

--- a/src/FlaUI.Mcp/Tools/TableTool.cs
+++ b/src/FlaUI.Mcp/Tools/TableTool.cs
@@ -146,36 +146,20 @@ public class TableTool : ToolBase
 
     private McpToolResult ReadViaTreeWalking(AutomationElement element, string? rowsParam, string? columnsParam)
     {
-        // Find header items
-        var headerElements = element.FindAllChildren(c =>
-            c.ByControlType(ControlType.Header));
-        var headers = new List<string>();
-        if (headerElements.Length > 0)
-        {
-            var headerItems = headerElements[0].FindAllChildren(c =>
-                c.ByControlType(ControlType.HeaderItem));
-            foreach (var item in headerItems)
-            {
-                headers.Add(item.Properties.Name.ValueOrDefault ?? "");
-            }
-        }
-
         // Find data rows
         var dataItems = element.FindAllChildren(c =>
             c.ByControlType(ControlType.DataItem));
         int totalRows = dataItems.Length;
 
-        // If no headers found, generate default names
-        int totalCols = headers.Count;
-        if (totalCols == 0 && dataItems.Length > 0)
+        // Determine column count from the first data row if available
+        int totalCols = 0;
+        if (dataItems.Length > 0)
         {
-            var firstRowCells = dataItems[0].FindAllChildren();
-            totalCols = firstRowCells.Length;
-            for (int i = 0; i < totalCols; i++)
-            {
-                headers.Add($"Column{i}");
-            }
+            totalCols = dataItems[0].FindAllChildren().Length;
         }
+
+        // Use the shared header detection logic
+        var headers = GetColumnHeaders(element, totalCols);
 
         // Determine which columns to include
         var (columnIndices, columnNames) = FilterColumns(headers, columnsParam, totalCols);
@@ -224,6 +208,36 @@ public class TableTool : ToolBase
 
     private List<string> GetColumnHeaders(AutomationElement element, int totalCols)
     {
+        List<string> headers;
+
+        // Strategy 1: Find a Header container with HeaderItem children (standard WPF/Win32 tables)
+        headers = TryHeaderContainerWithHeaderItems(element);
+        if (HasMeaningfulNames(headers))
+            return PadHeaders(headers, totalCols);
+
+        // Strategy 2: Find Header descendants at any depth (WinForms DataGridView uses
+        // ControlType.Header for individual column headers, not HeaderItem)
+        headers = TryDescendantsByType(element, ControlType.Header);
+        if (HasMeaningfulNames(headers))
+            return PadHeaders(headers, totalCols);
+
+        // Strategy 3: Find HeaderItem descendants at any depth
+        headers = TryDescendantsByType(element, ControlType.HeaderItem);
+        if (HasMeaningfulNames(headers))
+            return PadHeaders(headers, totalCols);
+
+        // Strategy 4: Use cell names from the first DataItem row
+        headers = TryCellNamesFromFirstRow(element);
+        if (HasMeaningfulNames(headers))
+            return PadHeaders(headers, totalCols);
+
+        // Strategy 5: Fall back to generic Column0, Column1, etc.
+        headers = new List<string>();
+        return PadHeaders(headers, totalCols);
+    }
+
+    private List<string> TryHeaderContainerWithHeaderItems(AutomationElement element)
+    {
         var headers = new List<string>();
         var headerElements = element.FindAllChildren(c =>
             c.ByControlType(ControlType.Header));
@@ -236,13 +250,49 @@ public class TableTool : ToolBase
                 headers.Add(item.Properties.Name.ValueOrDefault ?? "");
             }
         }
+        return headers;
+    }
 
-        // Pad with default names if needed
+    private List<string> TryDescendantsByType(AutomationElement element, ControlType controlType)
+    {
+        var headers = new List<string>();
+        var descendants = element.FindAllDescendants(cf => cf.ByControlType(controlType));
+        foreach (var desc in descendants)
+        {
+            var name = desc.Properties.Name.ValueOrDefault ?? "";
+            headers.Add(name);
+        }
+        return headers;
+    }
+
+    private List<string> TryCellNamesFromFirstRow(AutomationElement element)
+    {
+        var headers = new List<string>();
+        var dataItems = element.FindAllChildren(c =>
+            c.ByControlType(ControlType.DataItem));
+        if (dataItems.Length > 0)
+        {
+            var cells = dataItems[0].FindAllChildren();
+            foreach (var cell in cells)
+            {
+                var name = cell.Properties.Name.ValueOrDefault ?? "";
+                headers.Add(name);
+            }
+        }
+        return headers;
+    }
+
+    private static bool HasMeaningfulNames(List<string> headers)
+    {
+        return headers.Count > 0 && headers.Any(h => !string.IsNullOrEmpty(h));
+    }
+
+    private static List<string> PadHeaders(List<string> headers, int totalCols)
+    {
         while (headers.Count < totalCols)
         {
             headers.Add($"Column{headers.Count}");
         }
-
         return headers;
     }
 

--- a/src/FlaUI.Mcp/Tools/TableTool.cs
+++ b/src/FlaUI.Mcp/Tools/TableTool.cs
@@ -1,0 +1,330 @@
+using System.Text;
+using System.Text.Json;
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Definitions;
+using PlaywrightWindows.Mcp.Core;
+
+namespace PlaywrightWindows.Mcp.Tools;
+
+/// <summary>
+/// Read a table or grid control and return its data as a structured markdown table
+/// </summary>
+public class TableTool : ToolBase
+{
+    private readonly ElementRegistry _elementRegistry;
+
+    public TableTool(ElementRegistry elementRegistry)
+    {
+        _elementRegistry = elementRegistry;
+    }
+
+    public override string Name => "windows_table";
+
+    public override string Description =>
+        "Read a table or grid control and return its data as a structured markdown table. " +
+        "Use on table/grid elements found in windows_snapshot.";
+
+    public override object InputSchema => new
+    {
+        type = "object",
+        properties = new
+        {
+            @ref = new
+            {
+                type = "string",
+                description = "Element ref of a table/grid control from windows_snapshot (e.g., 'w1e5')"
+            },
+            rows = new
+            {
+                type = "string",
+                description = "Row range like '0-9', '0', '5-14'. Default: all rows."
+            },
+            columns = new
+            {
+                type = "string",
+                description = "Comma-separated column names to include. Default: all columns."
+            }
+        },
+        required = new[] { "ref" }
+    };
+
+    public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var refId = GetStringArgument(arguments, "ref");
+        if (string.IsNullOrEmpty(refId))
+        {
+            return Task.FromResult(ErrorResult("Missing required argument: ref"));
+        }
+
+        var element = _elementRegistry.GetElement(refId);
+        if (element == null)
+        {
+            return Task.FromResult(ErrorResult($"Element not found: {refId}. Run windows_snapshot to refresh element refs."));
+        }
+
+        try
+        {
+            var controlType = element.Properties.ControlType.ValueOrDefault;
+            if (controlType != ControlType.Table && controlType != ControlType.DataGrid)
+            {
+                return Task.FromResult(ErrorResult(
+                    $"Element {refId} is not a table or grid control (found: {controlType}). " +
+                    "Use this tool on Table or DataGrid elements from windows_snapshot."));
+            }
+
+            var rowsParam = GetStringArgument(arguments, "rows");
+            var columnsParam = GetStringArgument(arguments, "columns");
+
+            // Try Grid pattern first
+            if (element.Patterns.Grid.IsSupported)
+            {
+                return Task.FromResult(ReadViaGridPattern(element, rowsParam, columnsParam));
+            }
+
+            // Fall back to tree walking
+            return Task.FromResult(ReadViaTreeWalking(element, rowsParam, columnsParam));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(ErrorResult($"Failed to read table {refId}: {ex.Message}"));
+        }
+    }
+
+    private McpToolResult ReadViaGridPattern(AutomationElement element, string? rowsParam, string? columnsParam)
+    {
+        var gridPattern = element.Patterns.Grid.Pattern;
+        int totalRows = gridPattern.RowCount;
+        int totalCols = gridPattern.ColumnCount;
+
+        // Read headers from Header children
+        var headers = GetColumnHeaders(element, totalCols);
+
+        // Determine which columns to include
+        var (columnIndices, columnNames) = FilterColumns(headers, columnsParam, totalCols);
+
+        // Parse row range
+        var (startRow, endRow) = ParseRowRange(rowsParam, totalRows);
+
+        // Build markdown table
+        var sb = new StringBuilder();
+
+        // Header row
+        sb.Append('|');
+        foreach (var name in columnNames)
+        {
+            sb.Append($" {EscapePipe(name)} |");
+        }
+        sb.AppendLine();
+
+        // Separator row
+        sb.Append('|');
+        foreach (var _ in columnNames)
+        {
+            sb.Append(" --- |");
+        }
+        sb.AppendLine();
+
+        // Data rows
+        for (int row = startRow; row <= endRow && row < totalRows; row++)
+        {
+            sb.Append('|');
+            foreach (var col in columnIndices)
+            {
+                var cell = gridPattern.GetItem(row, col);
+                var value = GetCellValue(cell);
+                sb.Append($" {EscapePipe(value)} |");
+            }
+            sb.AppendLine();
+        }
+
+        int shownStart = startRow;
+        int shownEnd = Math.Min(endRow, totalRows - 1);
+        sb.AppendLine($"({totalRows} total rows, showing {shownStart}-{shownEnd})");
+
+        return TextResult(sb.ToString());
+    }
+
+    private McpToolResult ReadViaTreeWalking(AutomationElement element, string? rowsParam, string? columnsParam)
+    {
+        // Find header items
+        var headerElements = element.FindAllChildren(c =>
+            c.ByControlType(ControlType.Header));
+        var headers = new List<string>();
+        if (headerElements.Length > 0)
+        {
+            var headerItems = headerElements[0].FindAllChildren(c =>
+                c.ByControlType(ControlType.HeaderItem));
+            foreach (var item in headerItems)
+            {
+                headers.Add(item.Properties.Name.ValueOrDefault ?? "");
+            }
+        }
+
+        // Find data rows
+        var dataItems = element.FindAllChildren(c =>
+            c.ByControlType(ControlType.DataItem));
+        int totalRows = dataItems.Length;
+
+        // If no headers found, generate default names
+        int totalCols = headers.Count;
+        if (totalCols == 0 && dataItems.Length > 0)
+        {
+            var firstRowCells = dataItems[0].FindAllChildren();
+            totalCols = firstRowCells.Length;
+            for (int i = 0; i < totalCols; i++)
+            {
+                headers.Add($"Column{i}");
+            }
+        }
+
+        // Determine which columns to include
+        var (columnIndices, columnNames) = FilterColumns(headers, columnsParam, totalCols);
+
+        // Parse row range
+        var (startRow, endRow) = ParseRowRange(rowsParam, totalRows);
+
+        // Build markdown table
+        var sb = new StringBuilder();
+
+        // Header row
+        sb.Append('|');
+        foreach (var name in columnNames)
+        {
+            sb.Append($" {EscapePipe(name)} |");
+        }
+        sb.AppendLine();
+
+        // Separator row
+        sb.Append('|');
+        foreach (var _ in columnNames)
+        {
+            sb.Append(" --- |");
+        }
+        sb.AppendLine();
+
+        // Data rows
+        for (int row = startRow; row <= endRow && row < totalRows; row++)
+        {
+            var cells = dataItems[row].FindAllChildren();
+            sb.Append('|');
+            foreach (var col in columnIndices)
+            {
+                var value = col < cells.Length ? GetCellValue(cells[col]) : "";
+                sb.Append($" {EscapePipe(value)} |");
+            }
+            sb.AppendLine();
+        }
+
+        int shownStart = startRow;
+        int shownEnd = Math.Min(endRow, totalRows - 1);
+        sb.AppendLine($"({totalRows} total rows, showing {shownStart}-{shownEnd})");
+
+        return TextResult(sb.ToString());
+    }
+
+    private List<string> GetColumnHeaders(AutomationElement element, int totalCols)
+    {
+        var headers = new List<string>();
+        var headerElements = element.FindAllChildren(c =>
+            c.ByControlType(ControlType.Header));
+        if (headerElements.Length > 0)
+        {
+            var headerItems = headerElements[0].FindAllChildren(c =>
+                c.ByControlType(ControlType.HeaderItem));
+            foreach (var item in headerItems)
+            {
+                headers.Add(item.Properties.Name.ValueOrDefault ?? "");
+            }
+        }
+
+        // Pad with default names if needed
+        while (headers.Count < totalCols)
+        {
+            headers.Add($"Column{headers.Count}");
+        }
+
+        return headers;
+    }
+
+    private (List<int> indices, List<string> names) FilterColumns(List<string> allHeaders, string? columnsParam, int totalCols)
+    {
+        if (string.IsNullOrEmpty(columnsParam))
+        {
+            var allIndices = Enumerable.Range(0, totalCols).ToList();
+            return (allIndices, allHeaders.Take(totalCols).ToList());
+        }
+
+        var requestedNames = columnsParam.Split(',').Select(s => s.Trim()).ToList();
+        var indices = new List<int>();
+        var names = new List<string>();
+
+        foreach (var requested in requestedNames)
+        {
+            for (int i = 0; i < allHeaders.Count; i++)
+            {
+                if (string.Equals(allHeaders[i], requested, StringComparison.OrdinalIgnoreCase))
+                {
+                    indices.Add(i);
+                    names.Add(allHeaders[i]);
+                    break;
+                }
+            }
+        }
+
+        return (indices, names);
+    }
+
+    private (int start, int end) ParseRowRange(string? rowsParam, int totalRows)
+    {
+        if (string.IsNullOrEmpty(rowsParam))
+        {
+            return (0, totalRows - 1);
+        }
+
+        var parts = rowsParam.Split('-');
+        if (parts.Length == 1)
+        {
+            if (int.TryParse(parts[0].Trim(), out int single))
+            {
+                return (single, single);
+            }
+        }
+        else if (parts.Length == 2)
+        {
+            if (int.TryParse(parts[0].Trim(), out int start) &&
+                int.TryParse(parts[1].Trim(), out int end))
+            {
+                return (start, end);
+            }
+        }
+
+        return (0, totalRows - 1);
+    }
+
+    private string GetCellValue(AutomationElement cell)
+    {
+        try
+        {
+            // Try Value pattern
+            if (cell.Patterns.Value.IsSupported)
+            {
+                var val = cell.Patterns.Value.Pattern.Value.ValueOrDefault;
+                if (!string.IsNullOrEmpty(val)) return val;
+            }
+            // Try Toggle pattern for checkbox cells
+            if (cell.Patterns.Toggle.IsSupported)
+            {
+                var state = cell.Patterns.Toggle.Pattern.ToggleState.ValueOrDefault;
+                return state == ToggleState.On ? "[x]" : "[ ]";
+            }
+            // Fall back to Name
+            return cell.Properties.Name.ValueOrDefault ?? "";
+        }
+        catch { return ""; }
+    }
+
+    private static string EscapePipe(string value)
+    {
+        return value.Replace("|", "\\|");
+    }
+}

--- a/tests/FlaUI.Mcp.IntegrationTests/TableToolTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/TableToolTests.cs
@@ -1,0 +1,153 @@
+using System.Diagnostics;
+using PlaywrightWindows.Mcp.Tools;
+using Xunit.Abstractions;
+
+namespace FlaUI.Mcp.IntegrationTests;
+
+/// <summary>
+/// Tests for windows_table tool using the WinForms test app's 50-row DataGridView.
+/// </summary>
+[Collection("TestApps")]
+public class TableToolTests
+{
+    private readonly TestAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public TableToolTests(TestAppFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    /// <summary>
+    /// Navigate to Grid tab and return the table element ref.
+    /// </summary>
+    private async Task<string> GetGridRef()
+    {
+        var snapshot = _fixture.TakeSnapshot(_fixture.WinFormsHandle);
+        var tabRef = TestAppFixture.FindRefInSnapshot(snapshot, "Grid");
+        Assert.NotNull(tabRef);
+
+        var clickTool = new ClickTool(_fixture.Elements);
+        await _fixture.CallTool(clickTool, new { @ref = tabRef });
+
+        // Poll for grid to appear
+        var sw = Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < 5000)
+        {
+            await Task.Delay(100);
+            var gridRef = _fixture.FindRefByName(_fixture.WinFormsHandle, "Test Data");
+            if (gridRef != null) return gridRef;
+        }
+
+        Assert.Fail("Test Data grid not found after navigating to Grid tab.");
+        return "";
+    }
+
+    [Fact]
+    public async Task Table_ReturnsMarkdownFormat()
+    {
+        var gridRef = await GetGridRef();
+
+        var tool = new TableTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { @ref = gridRef, rows = "0-2" });
+        _output.WriteLine(result);
+
+        // Should have markdown table structure
+        Assert.Contains("|", result);
+        Assert.Contains("---", result);
+        Assert.Contains("total rows", result);
+    }
+
+    [Fact]
+    public async Task Table_HasCorrectColumnHeaders()
+    {
+        var gridRef = await GetGridRef();
+
+        var tool = new TableTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { @ref = gridRef, rows = "0" });
+        _output.WriteLine(result);
+
+        // Should use real column names, not Column0, Column1
+        Assert.Contains("Select", result);
+        Assert.Contains("ID", result);
+        Assert.Contains("Name", result);
+        Assert.Contains("Category", result);
+        Assert.Contains("Value", result);
+        Assert.DoesNotContain("Column0", result);
+    }
+
+    [Fact]
+    public async Task Table_RowRangeFilter()
+    {
+        var gridRef = await GetGridRef();
+
+        var tool = new TableTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { @ref = gridRef, rows = "0-4" });
+        _output.WriteLine(result);
+
+        // Should show rows 0-4 (5 rows) out of 50
+        Assert.Contains("showing 0-4", result);
+        Assert.Contains("50 total rows", result);
+    }
+
+    [Fact]
+    public async Task Table_SingleRow()
+    {
+        var gridRef = await GetGridRef();
+
+        var tool = new TableTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { @ref = gridRef, rows = "0" });
+        _output.WriteLine(result);
+
+        Assert.Contains("showing 0-0", result);
+    }
+
+    [Fact]
+    public async Task Table_ColumnFilter()
+    {
+        var gridRef = await GetGridRef();
+
+        var tool = new TableTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { @ref = gridRef, rows = "0-2", columns = "ID,Name" });
+        _output.WriteLine(result);
+
+        // Should include ID and Name columns
+        Assert.Contains("ID", result);
+        Assert.Contains("Name", result);
+        // Should not include other columns (except in data which might coincidentally match)
+        // Check the header line specifically
+        var headerLine = result.Split('\n').First(l => l.Contains("ID") && l.Contains("|"));
+        Assert.DoesNotContain("Category", headerLine);
+    }
+
+    [Fact]
+    public async Task Table_NonTableElement_ReturnsError()
+    {
+        // Find a button ref and try to use it as a table
+        var snapshot = _fixture.TakeSnapshot(_fixture.WinFormsHandle);
+        var buttonRef = TestAppFixture.FindRefInSnapshot(snapshot, "Buttons");
+        Assert.NotNull(buttonRef);
+
+        var tool = new TableTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { @ref = buttonRef });
+        _output.WriteLine(result);
+
+        Assert.Contains("not a table", result);
+    }
+
+    [Fact]
+    public async Task Table_ContainsDeterministicData()
+    {
+        var gridRef = await GetGridRef();
+
+        var tool = new TableTool(_fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { @ref = gridRef, rows = "0" });
+        _output.WriteLine(result);
+
+        // First row should have ITEM-001 (deterministic data from seeded random)
+        Assert.Contains("ITEM-001", result);
+        Assert.Contains("Test Item 1", result);
+        Assert.Contains("Alpha", result); // First category
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `windows_table` tool for reading table/grid controls as markdown tables
- Optional `rows` (range) and `columns` (comma-separated names) filtering
- Multi-strategy column header detection with corner cell filtering
- Handles WinForms DataGridView (non-standard ControlTypes, row headers, Grid pattern failures)
- Falls back from Grid pattern to tree walking when `GetItem` throws

## Tests
7 integration tests: markdown format, correct column headers (not Column0), row range, single row, column filter, non-table error, deterministic data verification.

Tests found and fixed 4 bugs: Grid pattern GetItem throws on WinForms, tree walking expected DataItem ControlType, row headers shifted cell indices, corner cell included as column header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)