### PR TITLE
Add UIA2 backend fallback for WinForms controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `windows_snapshot` now supports `backend` parameter (`uia3` or `uia2`) for UIA2 fallback on WinForms controls
 - **Integration test framework** with purpose-built WinForms (.NET Framework 4.8.1) and WPF (.NET 8) test applications
   - WinFormsTestApp: buttons, forms, 50-row DataGridView, TreeView, dialog launchers
   - WpfTestApp: equivalent WPF controls for cross-framework validation

--- a/src/FlaUI.Mcp/Core/SessionManager.cs
+++ b/src/FlaUI.Mcp/Core/SessionManager.cs
@@ -12,7 +12,7 @@ namespace PlaywrightWindows.Mcp.Core;
 public class SessionManager : IDisposable
 {
     private readonly UIA3Automation _automation;
-    private UIA2Automation? _uia2Automation;
+    private readonly Lazy<UIA2Automation> _uia2Automation = new(() => new UIA2Automation());
     private readonly Dictionary<string, FlaUIApplication> _applications = new();
     private readonly Dictionary<string, Window> _windows = new();
     private int _appCounter = 0;
@@ -25,7 +25,7 @@ public class SessionManager : IDisposable
 
     public UIA3Automation Automation => _automation;
 
-    public UIA2Automation UIA2Automation => _uia2Automation ??= new UIA2Automation();
+    public UIA2Automation UIA2Automation => _uia2Automation.Value;
 
     public (string handle, Window window) LaunchApp(string appPath, string[]? args = null)
     {
@@ -186,7 +186,8 @@ public class SessionManager : IDisposable
         }
         _applications.Clear();
         _windows.Clear();
-        _uia2Automation?.Dispose();
+        if (_uia2Automation.IsValueCreated)
+            _uia2Automation.Value.Dispose();
         _automation.Dispose();
     }
 }

--- a/src/FlaUI.Mcp/Core/SessionManager.cs
+++ b/src/FlaUI.Mcp/Core/SessionManager.cs
@@ -1,5 +1,6 @@
 using FlaUI.Core;
 using FlaUI.Core.AutomationElements;
+using FlaUI.UIA2;
 using FlaUI.UIA3;
 using FlaUIApplication = FlaUI.Core.Application;
 
@@ -11,6 +12,7 @@ namespace PlaywrightWindows.Mcp.Core;
 public class SessionManager : IDisposable
 {
     private readonly UIA3Automation _automation;
+    private UIA2Automation? _uia2Automation;
     private readonly Dictionary<string, FlaUIApplication> _applications = new();
     private readonly Dictionary<string, Window> _windows = new();
     private int _appCounter = 0;
@@ -22,6 +24,8 @@ public class SessionManager : IDisposable
     }
 
     public UIA3Automation Automation => _automation;
+
+    public UIA2Automation UIA2Automation => _uia2Automation ??= new UIA2Automation();
 
     public (string handle, Window window) LaunchApp(string appPath, string[]? args = null)
     {
@@ -182,6 +186,7 @@ public class SessionManager : IDisposable
         }
         _applications.Clear();
         _windows.Clear();
+        _uia2Automation?.Dispose();
         _automation.Dispose();
     }
 }

--- a/src/FlaUI.Mcp/FlaUI.Mcp.csproj
+++ b/src/FlaUI.Mcp/FlaUI.Mcp.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="FlaUI.Core" Version="5.0.0" />
+    <PackageReference Include="FlaUI.UIA2" Version="5.0.0" />
     <PackageReference Include="FlaUI.UIA3" Version="5.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.2" />
     <PackageReference Include="System.Text.Json" Version="10.0.2" />

--- a/src/FlaUI.Mcp/Tools/BatchTool.cs
+++ b/src/FlaUI.Mcp/Tools/BatchTool.cs
@@ -72,6 +72,12 @@ public class BatchTool : ToolBase
                         {
                             type = "string",
                             description = "Window handle for snapshot action"
+                        },
+                        backend = new
+                        {
+                            type = "string",
+                            @enum = new[] { "uia3", "uia2" },
+                            description = "Automation backend for snapshot action. UIA3 (default) works best for WPF/UWP. UIA2 may provide better results for older WinForms controls."
                         }
                     },
                     required = new[] { "action" }
@@ -233,7 +239,8 @@ public class BatchTool : ToolBase
     private string ExecuteSnapshot(JsonElement action)
     {
         var handle = action.TryGetProperty("handle", out var handleProp) ? handleProp.GetString() : null;
-        
+        var backend = action.TryGetProperty("backend", out var backendProp) ? backendProp.GetString() : null;
+
         Window? window = null;
         if (!string.IsNullOrEmpty(handle))
         {
@@ -266,6 +273,19 @@ public class BatchTool : ToolBase
         if (window == null)
         {
             return "No window found";
+        }
+
+        // If UIA2 backend requested, re-find the window using UIA2
+        if (string.Equals(backend, "uia2", StringComparison.OrdinalIgnoreCase))
+        {
+            var uia2 = _sessionManager.UIA2Automation;
+            var uia2Desktop = uia2.GetDesktop();
+            var windowTitle = window.Title;
+            var uia2Window = uia2Desktop.FindFirstDescendant(cf => cf.ByName(windowTitle))?.AsWindow();
+            if (uia2Window != null)
+            {
+                window = uia2Window;
+            }
         }
 
         var snapshot = _snapshotBuilder.BuildSnapshot(handle!, window);

--- a/src/FlaUI.Mcp/Tools/BatchTool.cs
+++ b/src/FlaUI.Mcp/Tools/BatchTool.cs
@@ -275,16 +275,17 @@ public class BatchTool : ToolBase
             return "No window found";
         }
 
-        // If UIA2 backend requested, re-find the window using UIA2
+        // If UIA2 backend requested, get the window via its native handle
         if (string.Equals(backend, "uia2", StringComparison.OrdinalIgnoreCase))
         {
-            var uia2 = _sessionManager.UIA2Automation;
-            var uia2Desktop = uia2.GetDesktop();
-            var windowTitle = window.Title;
-            var uia2Window = uia2Desktop.FindFirstDescendant(cf => cf.ByName(windowTitle))?.AsWindow();
-            if (uia2Window != null)
+            var hwnd = window.Properties.NativeWindowHandle.ValueOrDefault;
+            if (hwnd != IntPtr.Zero)
             {
-                window = uia2Window;
+                var uia2Window = _sessionManager.UIA2Automation.FromHandle(hwnd)?.AsWindow();
+                if (uia2Window != null)
+                {
+                    window = uia2Window;
+                }
             }
         }
 

--- a/src/FlaUI.Mcp/Tools/SnapshotTool.cs
+++ b/src/FlaUI.Mcp/Tools/SnapshotTool.cs
@@ -93,16 +93,17 @@ public class SnapshotTool : ToolBase
                 handle = _sessionManager.RegisterWindow(window);
             }
 
-            // If UIA2 backend requested, re-find the window using UIA2
+            // If UIA2 backend requested, get the window via its native handle
             if (string.Equals(backend, "uia2", StringComparison.OrdinalIgnoreCase))
             {
-                var uia2 = _sessionManager.UIA2Automation;
-                var uia2Desktop = uia2.GetDesktop();
-                var windowTitle = window.Title;
-                var uia2Window = uia2Desktop.FindFirstDescendant(cf => cf.ByName(windowTitle))?.AsWindow();
-                if (uia2Window != null)
+                var hwnd = window.Properties.NativeWindowHandle.ValueOrDefault;
+                if (hwnd != IntPtr.Zero)
                 {
-                    window = uia2Window;
+                    var uia2Window = _sessionManager.UIA2Automation.FromHandle(hwnd)?.AsWindow();
+                    if (uia2Window != null)
+                    {
+                        window = uia2Window;
+                    }
                 }
             }
 

--- a/src/FlaUI.Mcp/Tools/SnapshotTool.cs
+++ b/src/FlaUI.Mcp/Tools/SnapshotTool.cs
@@ -36,6 +36,12 @@ public class SnapshotTool : ToolBase
             {
                 type = "string",
                 description = "Window handle from windows_launch or windows_list_windows. If omitted, uses the most recently launched window."
+            },
+            backend = new
+            {
+                type = "string",
+                @enum = new[] { "uia3", "uia2" },
+                description = "Automation backend to use. UIA3 (default) works best for WPF/UWP. UIA2 may provide better results for older WinForms controls."
             }
         }
     };
@@ -43,6 +49,7 @@ public class SnapshotTool : ToolBase
     public override Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
     {
         var handle = GetStringArgument(arguments, "handle");
+        var backend = GetStringArgument(arguments, "backend");
 
         try
         {
@@ -61,7 +68,7 @@ public class SnapshotTool : ToolBase
                 // Get the foreground window
                 var desktop = _sessionManager.Automation.GetDesktop();
                 var focusedElement = _sessionManager.Automation.FocusedElement();
-                
+
                 if (focusedElement != null)
                 {
                     // Walk up to find the window
@@ -84,6 +91,19 @@ public class SnapshotTool : ToolBase
 
                 // Register this window
                 handle = _sessionManager.RegisterWindow(window);
+            }
+
+            // If UIA2 backend requested, re-find the window using UIA2
+            if (string.Equals(backend, "uia2", StringComparison.OrdinalIgnoreCase))
+            {
+                var uia2 = _sessionManager.UIA2Automation;
+                var uia2Desktop = uia2.GetDesktop();
+                var windowTitle = window.Title;
+                var uia2Window = uia2Desktop.FindFirstDescendant(cf => cf.ByName(windowTitle))?.AsWindow();
+                if (uia2Window != null)
+                {
+                    window = uia2Window;
+                }
             }
 
             var snapshot = _snapshotBuilder.BuildSnapshot(handle!, window);

--- a/tests/FlaUI.Mcp.IntegrationTests/Uia2FallbackTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/Uia2FallbackTests.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using PlaywrightWindows.Mcp;
+using PlaywrightWindows.Mcp.Core;
+using PlaywrightWindows.Mcp.Tools;
+using Xunit.Abstractions;
+
+namespace FlaUI.Mcp.IntegrationTests;
+
+/// <summary>
+/// Tests for the UIA2 backend fallback on windows_snapshot.
+/// </summary>
+[Collection("TestApps")]
+public class Uia2FallbackTests
+{
+    private readonly TestAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public Uia2FallbackTests(TestAppFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    [Fact]
+    public void Uia3_Snapshot_WinForms_ReturnsContent()
+    {
+        var tool = new SnapshotTool(_fixture.Session, _fixture.Elements);
+        var json = JsonSerializer.Serialize(new { handle = _fixture.WinFormsHandle, backend = "uia3" }, McpProtocol.JsonOptions);
+        var result = tool.ExecuteAsync(JsonSerializer.Deserialize<JsonElement>(json)).Result;
+        var text = result.Content.FirstOrDefault()?.Text ?? "";
+        _output.WriteLine($"UIA3 snapshot length: {text.Length}");
+        _output.WriteLine(text[..Math.Min(500, text.Length)]);
+
+        Assert.Contains("FlaUI-MCP Test App", text);
+    }
+
+    [Fact]
+    public void Uia2_Snapshot_WinForms_ReturnsContent()
+    {
+        var tool = new SnapshotTool(_fixture.Session, _fixture.Elements);
+        var json = JsonSerializer.Serialize(new { handle = _fixture.WinFormsHandle, backend = "uia2" }, McpProtocol.JsonOptions);
+        var result = tool.ExecuteAsync(JsonSerializer.Deserialize<JsonElement>(json)).Result;
+        var text = result.Content.FirstOrDefault()?.Text ?? "";
+        _output.WriteLine($"UIA2 snapshot length: {text.Length}");
+        _output.WriteLine(text[..Math.Min(500, text.Length)]);
+
+        Assert.Contains("FlaUI-MCP Test App", text);
+    }
+
+    [Fact]
+    public void Uia2_Snapshot_MayDifferFromUia3()
+    {
+        var tool = new SnapshotTool(_fixture.Session, _fixture.Elements);
+
+        var json3 = JsonSerializer.Serialize(new { handle = _fixture.WinFormsHandle, backend = "uia3" }, McpProtocol.JsonOptions);
+        var result3 = tool.ExecuteAsync(JsonSerializer.Deserialize<JsonElement>(json3)).Result;
+        var text3 = result3.Content.FirstOrDefault()?.Text ?? "";
+
+        var json2 = JsonSerializer.Serialize(new { handle = _fixture.WinFormsHandle, backend = "uia2" }, McpProtocol.JsonOptions);
+        var result2 = tool.ExecuteAsync(JsonSerializer.Deserialize<JsonElement>(json2)).Result;
+        var text2 = result2.Content.FirstOrDefault()?.Text ?? "";
+
+        _output.WriteLine($"UIA3 length: {text3.Length}, UIA2 length: {text2.Length}");
+        _output.WriteLine($"Snapshots identical: {text3 == text2}");
+
+        // Both should contain the window, but may have structural differences
+        Assert.Contains("FlaUI-MCP Test App", text3);
+        Assert.Contains("FlaUI-MCP Test App", text2);
+        // It's okay if they differ — the point is both work
+    }
+
+    [Fact]
+    public void Default_Backend_IsUia3()
+    {
+        var tool = new SnapshotTool(_fixture.Session, _fixture.Elements);
+
+        // No backend specified
+        var jsonDefault = JsonSerializer.Serialize(new { handle = _fixture.WinFormsHandle }, McpProtocol.JsonOptions);
+        var resultDefault = tool.ExecuteAsync(JsonSerializer.Deserialize<JsonElement>(jsonDefault)).Result;
+        var textDefault = resultDefault.Content.FirstOrDefault()?.Text ?? "";
+
+        // Explicit UIA3
+        var json3 = JsonSerializer.Serialize(new { handle = _fixture.WinFormsHandle, backend = "uia3" }, McpProtocol.JsonOptions);
+        var result3 = tool.ExecuteAsync(JsonSerializer.Deserialize<JsonElement>(json3)).Result;
+        var text3 = result3.Content.FirstOrDefault()?.Text ?? "";
+
+        _output.WriteLine($"Default length: {textDefault.Length}, UIA3 length: {text3.Length}");
+
+        // Default and explicit UIA3 should produce the same result
+        Assert.Equal(textDefault, text3);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds optional `backend` parameter to `windows_snapshot`: `uia3` (default) or `uia2`
- UIA2 provides better accessibility data for some WinForms controls (IAccessible/MSAA)
- Lazy-initialized UIA2 automation instance (only created on first use)
- Also supported in `windows_batch` snapshot action

## Tests
4 integration tests: UIA3 snapshot, UIA2 snapshot, comparison between backends, default-is-UIA3 verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)