### PR TITLE
Add windows_wait tool for polling UI element state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - WpfTestApp: equivalent WPF controls for cross-framework validation
   - 13 integration tests covering snapshot, click, and text tools
   - Shared test fixture for stable window handles across test runs
+- `windows_wait` tool for polling UI elements until they reach a target state (exists, gone, enabled, focused)
+
+### Fixed
+- `windows_wait` with `state='gone'` enumerates fresh top-level windows to avoid stale desktop cache
 
 ## [0.1.0] - 2024-02-02
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Or using `dotnet run`:
 | `windows_focus` | Bring a window to foreground |
 | `windows_close` | Close a window |
 | `windows_batch` | Execute multiple actions in one call |
+| `windows_wait` | Wait for an element to reach a target state |
 
 ## How It Works
 

--- a/src/FlaUI.Mcp/Program.cs
+++ b/src/FlaUI.Mcp/Program.cs
@@ -18,6 +18,7 @@ toolRegistry.RegisterTool(new ScreenshotTool(sessionManager, elementRegistry));
 toolRegistry.RegisterTool(new ListWindowsTool(sessionManager));
 toolRegistry.RegisterTool(new FocusWindowTool(sessionManager));
 toolRegistry.RegisterTool(new CloseWindowTool(sessionManager));
+toolRegistry.RegisterTool(new WaitTool(sessionManager, elementRegistry));
 toolRegistry.RegisterTool(new BatchTool(sessionManager, elementRegistry));
 
 // Create and run MCP server

--- a/src/FlaUI.Mcp/Tools/WaitTool.cs
+++ b/src/FlaUI.Mcp/Tools/WaitTool.cs
@@ -74,12 +74,9 @@ public class WaitTool : ToolBase
         var state = GetStringArgument(arguments, "state") ?? "exists";
         var timeout = GetArgument<int?>(arguments, "timeout") ?? 30;
 
-        if (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(automationId) && string.IsNullOrEmpty(role))
+        if (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(automationId) && string.IsNullOrEmpty(role) && string.IsNullOrEmpty(handle))
         {
-            if (state != "gone" || string.IsNullOrEmpty(handle))
-            {
-                return ErrorResult("At least one search criterion (name, automationId, or role) is required.");
-            }
+            return ErrorResult("At least one search criterion (handle, name, automationId, or role) is required.");
         }
 
         ControlType? roleControlType = null;
@@ -99,40 +96,51 @@ public class WaitTool : ToolBase
         {
             try
             {
-                AutomationElement? searchRoot = null;
+                AutomationElement? found = null;
+                var hasCriteria = !string.IsNullOrEmpty(name) || !string.IsNullOrEmpty(automationId) || roleControlType != null;
 
                 if (!string.IsNullOrEmpty(handle))
                 {
+                    // Searching within a specific window handle
                     var window = _sessionManager.GetWindow(handle);
                     if (window == null)
                     {
                         if (state == "gone")
-                        {
-                            var elapsed = sw.Elapsed.TotalSeconds;
-                            return TextResult($"OK (element gone after {elapsed:F1}s)");
-                        }
+                            return TextResult($"OK (element gone after {sw.Elapsed.TotalSeconds:F1}s)");
                         return ErrorResult($"Window not found: {handle}");
                     }
-                    searchRoot = window;
+
+                    if (hasCriteria)
+                    {
+                        found = SearchDescendants(window, name, automationId, roleControlType);
+                    }
+
+                    // For "gone" with handle + no criteria, check if window is still alive
+                    if (state == "gone" && !hasCriteria)
+                    {
+                        _ = window.Properties.ProcessId.Value;
+                        // If we get here, window is still alive — keep waiting
+                    }
                 }
                 else
                 {
-                    searchRoot = _sessionManager.Automation.GetDesktop();
-                }
+                    // Searching across all windows via desktop.
+                    // Enumerate fresh top-level windows to avoid stale desktop cache.
+                    var desktop = _sessionManager.Automation.GetDesktop();
+                    var topLevelWindows = desktop.FindAllChildren(
+                        cf => cf.ByControlType(ControlType.Window));
 
-                // Search for matching elements
-                AutomationElement? found = null;
-                var hasCriteria = !string.IsNullOrEmpty(name) || !string.IsNullOrEmpty(automationId) || roleControlType != null;
-
-                if (hasCriteria)
-                {
-                    var descendants = searchRoot.FindAllDescendants();
-                    foreach (var element in descendants)
+                    if (hasCriteria)
                     {
-                        if (MatchesElement(element, name, automationId, roleControlType))
+                        foreach (var win in topLevelWindows)
                         {
-                            found = element;
-                            break;
+                            if (MatchesElement(win, name, automationId, roleControlType))
+                            {
+                                found = win;
+                                break;
+                            }
+                            found = SearchDescendants(win, name, automationId, roleControlType);
+                            if (found != null) break;
                         }
                     }
                 }
@@ -141,65 +149,30 @@ public class WaitTool : ToolBase
                 {
                     case "exists":
                         if (found != null)
-                        {
-                            var result = BuildFoundResult(found, handle, sw.Elapsed.TotalSeconds);
-                            return result;
-                        }
+                            return BuildFoundResult(found, handle, sw.Elapsed.TotalSeconds);
                         break;
 
                     case "gone":
-                        if (!hasCriteria && !string.IsNullOrEmpty(handle))
-                        {
-                            // No criteria + handle: check if window still exists
-                            // Window exists (we got past the null check above), keep waiting
-                        }
-                        else if (found == null)
-                        {
-                            var elapsed = sw.Elapsed.TotalSeconds;
-                            return TextResult($"OK (element gone after {elapsed:F1}s)");
-                        }
+                        if (found == null)
+                            return TextResult($"OK (element gone after {sw.Elapsed.TotalSeconds:F1}s)");
                         break;
 
                     case "enabled":
                         if (found != null && found.Properties.IsEnabled.ValueOrDefault)
-                        {
-                            var result = BuildFoundResult(found, handle, sw.Elapsed.TotalSeconds);
-                            return result;
-                        }
+                            return BuildFoundResult(found, handle, sw.Elapsed.TotalSeconds);
                         break;
 
                     case "focused":
-                        if (found != null)
-                        {
-                            try
-                            {
-                                var focusedElement = _sessionManager.Automation.FocusedElement();
-                                if (focusedElement != null &&
-                                    found.Properties.AutomationId.ValueOrDefault == focusedElement.Properties.AutomationId.ValueOrDefault &&
-                                    found.Properties.Name.ValueOrDefault == focusedElement.Properties.Name.ValueOrDefault &&
-                                    found.Properties.ControlType.ValueOrDefault == focusedElement.Properties.ControlType.ValueOrDefault)
-                                {
-                                    var result = BuildFoundResult(found, handle, sw.Elapsed.TotalSeconds);
-                                    return result;
-                                }
-                            }
-                            catch
-                            {
-                                // Focus check can fail during transitions
-                            }
-                        }
+                        if (found != null && found.Properties.HasKeyboardFocus.ValueOrDefault)
+                            return BuildFoundResult(found, handle, sw.Elapsed.TotalSeconds);
                         break;
                 }
             }
             catch
             {
                 // UI elements can go stale or become inaccessible during transitions
-                // For "gone" state, an exception accessing the element means it's gone
                 if (state == "gone")
-                {
-                    var elapsed = sw.Elapsed.TotalSeconds;
-                    return TextResult($"OK (element gone after {elapsed:F1}s)");
-                }
+                    return TextResult($"OK (element gone after {sw.Elapsed.TotalSeconds:F1}s)");
             }
 
             await Task.Delay(250);
@@ -215,7 +188,23 @@ public class WaitTool : ToolBase
         return ErrorResult($"Timeout after {timeout}s waiting for element ({criteriaStr}, state='{state}')");
     }
 
-    private bool MatchesElement(AutomationElement element, string? name, string? automationId, ControlType? roleControlType)
+    private static AutomationElement? SearchDescendants(
+        AutomationElement root, string? name, string? automationId, ControlType? roleControlType)
+    {
+        try
+        {
+            var descendants = root.FindAllDescendants();
+            foreach (var element in descendants)
+            {
+                if (MatchesElement(element, name, automationId, roleControlType))
+                    return element;
+            }
+        }
+        catch { }
+        return null;
+    }
+
+    private static bool MatchesElement(AutomationElement element, string? name, string? automationId, ControlType? roleControlType)
     {
         if (!string.IsNullOrEmpty(name))
         {

--- a/src/FlaUI.Mcp/Tools/WaitTool.cs
+++ b/src/FlaUI.Mcp/Tools/WaitTool.cs
@@ -194,6 +194,12 @@ public class WaitTool : ToolBase
             catch
             {
                 // UI elements can go stale or become inaccessible during transitions
+                // For "gone" state, an exception accessing the element means it's gone
+                if (state == "gone")
+                {
+                    var elapsed = sw.Elapsed.TotalSeconds;
+                    return TextResult($"OK (element gone after {elapsed:F1}s)");
+                }
             }
 
             await Task.Delay(250);

--- a/src/FlaUI.Mcp/Tools/WaitTool.cs
+++ b/src/FlaUI.Mcp/Tools/WaitTool.cs
@@ -1,0 +1,376 @@
+using System.Diagnostics;
+using System.Text.Json;
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Definitions;
+using PlaywrightWindows.Mcp.Core;
+
+namespace PlaywrightWindows.Mcp.Tools;
+
+/// <summary>
+/// Wait for a UI element to appear, disappear, or reach a specific state
+/// </summary>
+public class WaitTool : ToolBase
+{
+    private readonly SessionManager _sessionManager;
+    private readonly ElementRegistry _elementRegistry;
+
+    public WaitTool(SessionManager sessionManager, ElementRegistry elementRegistry)
+    {
+        _sessionManager = sessionManager;
+        _elementRegistry = elementRegistry;
+    }
+
+    public override string Name => "windows_wait";
+
+    public override string Description =>
+        "Wait for a UI element to appear, disappear, or reach a specific state. " +
+        "Polls the accessibility tree until the condition is met or timeout expires.";
+
+    public override object InputSchema => new
+    {
+        type = "object",
+        properties = new
+        {
+            handle = new
+            {
+                type = "string",
+                description = "Window handle to search within. If omitted, searches all windows via desktop."
+            },
+            name = new
+            {
+                type = "string",
+                description = "Wait for element with this name (case-insensitive substring match)"
+            },
+            automationId = new
+            {
+                type = "string",
+                description = "Wait for element with this AutomationId (exact match)"
+            },
+            role = new
+            {
+                type = "string",
+                description = "Filter by role (e.g., \"button\", \"window\", \"textbox\")"
+            },
+            state = new
+            {
+                type = "string",
+                description = "What condition to wait for (default: \"exists\")",
+                @enum = new[] { "exists", "gone", "enabled", "focused" }
+            },
+            timeout = new
+            {
+                type = "integer",
+                description = "Max wait time in seconds (default: 30)"
+            }
+        }
+    };
+
+    public override async Task<McpToolResult> ExecuteAsync(JsonElement? arguments)
+    {
+        var handle = GetStringArgument(arguments, "handle");
+        var name = GetStringArgument(arguments, "name");
+        var automationId = GetStringArgument(arguments, "automationId");
+        var role = GetStringArgument(arguments, "role");
+        var state = GetStringArgument(arguments, "state") ?? "exists";
+        var timeout = GetArgument<int?>(arguments, "timeout") ?? 30;
+
+        if (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(automationId) && string.IsNullOrEmpty(role))
+        {
+            if (state != "gone" || string.IsNullOrEmpty(handle))
+            {
+                return ErrorResult("At least one search criterion (name, automationId, or role) is required.");
+            }
+        }
+
+        ControlType? roleControlType = null;
+        if (!string.IsNullOrEmpty(role))
+        {
+            roleControlType = MapRoleToControlType(role);
+            if (roleControlType == null)
+            {
+                return ErrorResult($"Unknown role: {role}");
+            }
+        }
+
+        var sw = Stopwatch.StartNew();
+        var timeoutMs = timeout * 1000;
+
+        while (sw.ElapsedMilliseconds < timeoutMs)
+        {
+            try
+            {
+                AutomationElement? searchRoot = null;
+
+                if (!string.IsNullOrEmpty(handle))
+                {
+                    var window = _sessionManager.GetWindow(handle);
+                    if (window == null)
+                    {
+                        if (state == "gone")
+                        {
+                            var elapsed = sw.Elapsed.TotalSeconds;
+                            return TextResult($"OK (element gone after {elapsed:F1}s)");
+                        }
+                        return ErrorResult($"Window not found: {handle}");
+                    }
+                    searchRoot = window;
+                }
+                else
+                {
+                    searchRoot = _sessionManager.Automation.GetDesktop();
+                }
+
+                // Search for matching elements
+                AutomationElement? found = null;
+                var hasCriteria = !string.IsNullOrEmpty(name) || !string.IsNullOrEmpty(automationId) || roleControlType != null;
+
+                if (hasCriteria)
+                {
+                    var descendants = searchRoot.FindAllDescendants();
+                    foreach (var element in descendants)
+                    {
+                        if (MatchesElement(element, name, automationId, roleControlType))
+                        {
+                            found = element;
+                            break;
+                        }
+                    }
+                }
+
+                switch (state)
+                {
+                    case "exists":
+                        if (found != null)
+                        {
+                            var result = BuildFoundResult(found, handle, sw.Elapsed.TotalSeconds);
+                            return result;
+                        }
+                        break;
+
+                    case "gone":
+                        if (!hasCriteria && !string.IsNullOrEmpty(handle))
+                        {
+                            // No criteria + handle: check if window still exists
+                            // Window exists (we got past the null check above), keep waiting
+                        }
+                        else if (found == null)
+                        {
+                            var elapsed = sw.Elapsed.TotalSeconds;
+                            return TextResult($"OK (element gone after {elapsed:F1}s)");
+                        }
+                        break;
+
+                    case "enabled":
+                        if (found != null && found.Properties.IsEnabled.ValueOrDefault)
+                        {
+                            var result = BuildFoundResult(found, handle, sw.Elapsed.TotalSeconds);
+                            return result;
+                        }
+                        break;
+
+                    case "focused":
+                        if (found != null)
+                        {
+                            try
+                            {
+                                var focusedElement = _sessionManager.Automation.FocusedElement();
+                                if (focusedElement != null &&
+                                    found.Properties.AutomationId.ValueOrDefault == focusedElement.Properties.AutomationId.ValueOrDefault &&
+                                    found.Properties.Name.ValueOrDefault == focusedElement.Properties.Name.ValueOrDefault &&
+                                    found.Properties.ControlType.ValueOrDefault == focusedElement.Properties.ControlType.ValueOrDefault)
+                                {
+                                    var result = BuildFoundResult(found, handle, sw.Elapsed.TotalSeconds);
+                                    return result;
+                                }
+                            }
+                            catch
+                            {
+                                // Focus check can fail during transitions
+                            }
+                        }
+                        break;
+                }
+            }
+            catch
+            {
+                // UI elements can go stale or become inaccessible during transitions
+            }
+
+            await Task.Delay(250);
+        }
+
+        // Timeout
+        var criteria = new List<string>();
+        if (!string.IsNullOrEmpty(name)) criteria.Add($"name='{name}'");
+        if (!string.IsNullOrEmpty(automationId)) criteria.Add($"automationId='{automationId}'");
+        if (!string.IsNullOrEmpty(role)) criteria.Add($"role='{role}'");
+        var criteriaStr = criteria.Count > 0 ? string.Join(", ", criteria) : "window";
+
+        return ErrorResult($"Timeout after {timeout}s waiting for element ({criteriaStr}, state='{state}')");
+    }
+
+    private bool MatchesElement(AutomationElement element, string? name, string? automationId, ControlType? roleControlType)
+    {
+        if (!string.IsNullOrEmpty(name))
+        {
+            var elementName = element.Properties.Name.ValueOrDefault;
+            if (string.IsNullOrEmpty(elementName) ||
+                !elementName.Contains(name, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(automationId))
+        {
+            var elementAutomationId = element.Properties.AutomationId.ValueOrDefault;
+            if (!string.Equals(elementAutomationId, automationId, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        if (roleControlType != null)
+        {
+            var elementControlType = element.Properties.ControlType.ValueOrDefault;
+            if (elementControlType != roleControlType.Value)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private McpToolResult BuildFoundResult(AutomationElement element, string? handle, double elapsedSeconds)
+    {
+        // Determine the window handle for registration
+        var windowHandle = handle;
+        if (string.IsNullOrEmpty(windowHandle))
+        {
+            // Walk up to find the containing window
+            var current = element;
+            Window? parentWindow = null;
+            while (current != null)
+            {
+                if (current.Properties.ControlType.ValueOrDefault == ControlType.Window)
+                {
+                    parentWindow = current.AsWindow();
+                    break;
+                }
+                current = current.Parent;
+            }
+
+            if (parentWindow != null)
+            {
+                windowHandle = _sessionManager.RegisterWindow(parentWindow);
+            }
+            else
+            {
+                // Fallback: register under a synthetic handle
+                windowHandle = _sessionManager.RegisterWindow(element.AsWindow() ?? _sessionManager.Automation.GetDesktop().AsWindow()!);
+            }
+        }
+
+        var refId = _elementRegistry.Register(windowHandle!, element);
+
+        // Build the element description line
+        var role = GetRoleString(element);
+        var elementName = element.Properties.Name.ValueOrDefault;
+        var states = new List<string>();
+
+        if (!element.Properties.IsEnabled.ValueOrDefault)
+            states.Add("disabled");
+        if (element.Properties.IsOffscreen.ValueOrDefault)
+            states.Add("offscreen");
+
+        var line = role;
+        if (!string.IsNullOrEmpty(elementName))
+        {
+            line += $" \"{elementName.Replace("\"", "\\\"")}\"";
+        }
+        line += $" [ref={refId}]";
+        foreach (var s in states)
+        {
+            line += $" [{s}]";
+        }
+
+        return TextResult($"Found after {elapsedSeconds:F1}s\n{line}");
+    }
+
+    private static string GetRoleString(AutomationElement element)
+    {
+        try
+        {
+            var controlType = element.Properties.ControlType.ValueOrDefault;
+            return controlType switch
+            {
+                ControlType.Button => "button",
+                ControlType.Edit => "textbox",
+                ControlType.Text => "text",
+                ControlType.CheckBox => "checkbox",
+                ControlType.RadioButton => "radio",
+                ControlType.ComboBox => "combobox",
+                ControlType.List => "list",
+                ControlType.ListItem => "listitem",
+                ControlType.Menu => "menu",
+                ControlType.MenuItem => "menuitem",
+                ControlType.MenuBar => "menubar",
+                ControlType.Tree => "tree",
+                ControlType.TreeItem => "treeitem",
+                ControlType.Tab => "tablist",
+                ControlType.TabItem => "tab",
+                ControlType.Table => "table",
+                ControlType.DataItem => "row",
+                ControlType.Header => "header",
+                ControlType.HeaderItem => "columnheader",
+                ControlType.Slider => "slider",
+                ControlType.Window => "window",
+                ControlType.Group => "group",
+                ControlType.Pane => "group",
+                ControlType.DataGrid => "grid",
+                ControlType.Hyperlink => "link",
+                ControlType.Image => "image",
+                ControlType.ToolBar => "toolbar",
+                ControlType.Document => "document",
+                _ => "element"
+            };
+        }
+        catch
+        {
+            return "element";
+        }
+    }
+
+    private static ControlType? MapRoleToControlType(string role) => role switch
+    {
+        "button" => ControlType.Button,
+        "textbox" => ControlType.Edit,
+        "text" => ControlType.Text,
+        "checkbox" => ControlType.CheckBox,
+        "radio" => ControlType.RadioButton,
+        "combobox" => ControlType.ComboBox,
+        "list" => ControlType.List,
+        "listitem" => ControlType.ListItem,
+        "menu" => ControlType.Menu,
+        "menuitem" => ControlType.MenuItem,
+        "menubar" => ControlType.MenuBar,
+        "tree" => ControlType.Tree,
+        "treeitem" => ControlType.TreeItem,
+        "tablist" => ControlType.Tab,
+        "tab" => ControlType.TabItem,
+        "table" => ControlType.Table,
+        "row" => ControlType.DataItem,
+        "header" => ControlType.Header,
+        "columnheader" => ControlType.HeaderItem,
+        "slider" => ControlType.Slider,
+        "window" => ControlType.Window,
+        "group" => ControlType.Group,
+        "grid" => ControlType.DataGrid,
+        "link" => ControlType.Hyperlink,
+        "image" => ControlType.Image,
+        "toolbar" => ControlType.ToolBar,
+        "document" => ControlType.Document,
+        _ => null
+    };
+}

--- a/tests/FlaUI.Mcp.IntegrationTests/WaitTests.cs
+++ b/tests/FlaUI.Mcp.IntegrationTests/WaitTests.cs
@@ -1,0 +1,146 @@
+using System.Diagnostics;
+using PlaywrightWindows.Mcp.Tools;
+using Xunit.Abstractions;
+
+namespace FlaUI.Mcp.IntegrationTests;
+
+/// <summary>
+/// Tests for windows_wait tool using the test apps.
+/// </summary>
+[Collection("TestApps")]
+public class WaitTests
+{
+    private readonly TestAppFixture _fixture;
+    private readonly ITestOutputHelper _output;
+
+    public WaitTests(TestAppFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+    }
+
+    [Fact]
+    public async Task Wait_Exists_FindsRunningWindow()
+    {
+        var tool = new WaitTool(_fixture.Session, _fixture.Elements);
+        var sw = Stopwatch.StartNew();
+        var result = await _fixture.CallTool(tool, new
+        {
+            name = "FlaUI-MCP Test App",
+            role = "window",
+            state = "exists",
+            timeout = 5
+        });
+        sw.Stop();
+
+        _output.WriteLine($"Result: {result}");
+        _output.WriteLine($"Elapsed: {sw.Elapsed.TotalSeconds:F1}s");
+
+        Assert.Contains("Found", result);
+        Assert.Contains("FlaUI-MCP Test App", result);
+        Assert.True(sw.Elapsed.TotalSeconds < 3, "Should find quickly");
+    }
+
+    [Fact]
+    public async Task Wait_Gone_NonexistentWindow_ReturnsImmediately()
+    {
+        var tool = new WaitTool(_fixture.Session, _fixture.Elements);
+        var sw = Stopwatch.StartNew();
+        var result = await _fixture.CallTool(tool, new
+        {
+            name = "This Window Does Not Exist 12345",
+            role = "window",
+            state = "gone",
+            timeout = 5
+        });
+        sw.Stop();
+
+        _output.WriteLine($"Result: {result}");
+        _output.WriteLine($"Elapsed: {sw.Elapsed.TotalSeconds:F1}s");
+
+        Assert.Contains("gone", result, StringComparison.OrdinalIgnoreCase);
+        Assert.True(sw.Elapsed.TotalSeconds < 4, $"Should return before timeout but took {sw.Elapsed.TotalSeconds:F1}s");
+    }
+
+    [Fact]
+    public async Task Wait_Exists_WithHandle_FindsElement()
+    {
+        // Navigate to Buttons tab
+        var snapshot = _fixture.TakeSnapshot(_fixture.WinFormsHandle);
+        var tabRef = TestAppFixture.FindRefInSnapshot(snapshot, "Buttons");
+        Assert.NotNull(tabRef);
+        var clickTool = new ClickTool(_fixture.Elements);
+        await _fixture.CallTool(clickTool, new { @ref = tabRef });
+        await Task.Delay(100);
+
+        var tool = new WaitTool(_fixture.Session, _fixture.Elements);
+        var result = await _fixture.CallTool(tool, new
+        {
+            handle = _fixture.WinFormsHandle,
+            name = "Click Me",
+            role = "button",
+            state = "exists",
+            timeout = 5
+        });
+        _output.WriteLine($"Result: {result}");
+
+        Assert.Contains("Found", result);
+        Assert.Contains("Click Me", result);
+        Assert.Contains("[ref=", result);
+    }
+
+    [Fact]
+    public async Task Wait_Enabled_FindsEnabledButton()
+    {
+        // Navigate to Buttons tab, ensure checkbox is unchecked
+        var snapshot = _fixture.TakeSnapshot(_fixture.WinFormsHandle);
+        var tabRef = TestAppFixture.FindRefInSnapshot(snapshot, "Buttons");
+        Assert.NotNull(tabRef);
+        var clickTool = new ClickTool(_fixture.Elements);
+        await _fixture.CallTool(clickTool, new { @ref = tabRef });
+        await Task.Delay(100);
+
+        // "Click Me" button is always enabled
+        var tool = new WaitTool(_fixture.Session, _fixture.Elements);
+        var result = await _fixture.CallTool(tool, new
+        {
+            handle = _fixture.WinFormsHandle,
+            name = "Click Me",
+            state = "enabled",
+            timeout = 5
+        });
+        _output.WriteLine($"Result: {result}");
+
+        Assert.Contains("Found", result);
+    }
+
+    [Fact]
+    public async Task Wait_Timeout_ReturnsError()
+    {
+        var tool = new WaitTool(_fixture.Session, _fixture.Elements);
+        var sw = Stopwatch.StartNew();
+        var result = await _fixture.CallTool(tool, new
+        {
+            name = "This Element Will Never Appear",
+            state = "exists",
+            timeout = 2
+        });
+        sw.Stop();
+
+        _output.WriteLine($"Result: {result}");
+        _output.WriteLine($"Elapsed: {sw.Elapsed.TotalSeconds:F1}s");
+
+        Assert.Contains("Timeout", result);
+        Assert.True(sw.Elapsed.TotalSeconds >= 1.5, "Should wait near the timeout duration");
+    }
+
+    [Fact]
+    public async Task Wait_NoCriteria_ReturnsError()
+    {
+        var tool = new WaitTool(_fixture.Session, _fixture.Elements);
+        var result = await _fixture.CallTool(tool, new { state = "exists", timeout = 1 });
+        _output.WriteLine($"Result: {result}");
+
+        Assert.Contains("criterion", result, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `windows_wait` tool that polls for elements to appear, disappear, or reach a state
- States: `exists` (default), `gone`, `enabled`, `focused`
- Search by `name` (substring), `automationId` (exact), `role` (control type)
- Configurable `timeout` (default 30s), polls every 250ms
- For `gone` state, enumerates fresh top-level windows to avoid stale UIA desktop cache

## Tests
6 integration tests: exists finds running window, gone returns immediately for nonexistent, exists with handle, enabled state, timeout error, no-criteria validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)